### PR TITLE
fix: disable rmcp session keep-alive to prevent ✘ failed flicker

### DIFF
--- a/kaeru-mcp/src/main.rs
+++ b/kaeru-mcp/src/main.rs
@@ -72,12 +72,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let server = KaeruServer::new(store);
 
     let cancel = CancellationToken::new();
+    let mut session_manager = LocalSessionManager::default();
+    // rmcp defaults to a 5-minute idle timeout that reaps Claude Code MCP
+    // sessions during normal interactive pauses. The reaped sessions appear
+    // as `kaeru · ✘ failed` in the client UI before auto-reconnect. Disable
+    // the timeout — sessions live as long as the underlying connection.
+    session_manager.session_config.keep_alive = None;
     let service = StreamableHttpService::new(
         // Each MCP session reuses the same KaeruServer (and therefore
         // the same Arc<Store> / RocksDB lock); cloning the server is
         // cheap and shares state across sessions.
         move || Ok(server.clone()),
-        LocalSessionManager::default().into(),
+        std::sync::Arc::new(session_manager),
         StreamableHttpServerConfig::default()
             .with_cancellation_token(cancel.child_token()),
     );


### PR DESCRIPTION
## Summary

- rmcp's `LocalSessionManager` defaults to `keep_alive: Some(Duration::from_secs(300))`. After 5 minutes of MCP idleness the worker quits with `keep alive timeout after 300000ms`, the existing session is torn down, and the client (Claude Code, Cursor, …) shows `kaeru · ✘ failed` until auto-reconnect succeeds 1–6s later.
- For interactive editor sessions where the agent may sit idle for many minutes between calls this is the dominant UX issue.
- Build the manager explicitly and set `keep_alive = None`. Sessions then live as long as the underlying HTTP/SSE connection.

## Test plan

- [x] `cargo check --workspace` passes
- [x] Daemon survives >30 min of idleness with an attached Claude Code session — no `worker quit with fatal: keep alive timeout` in `journalctl --user -u kaeru-mcp`, no `✘ failed` in the client UI
- [ ] Reviewer validates: idle for 5+ minutes against this build, confirm session stays connected (no auto-reconnect spam)

## Notes

The default 5-min reaper makes sense for non-interactive proxy deployments where a hung client should free server resources. For an editor-attached MCP daemon the assumption is inverted — the client is *expected* to be quiet between user prompts. Disabling the reaper trades a small amount of server-side cleanup laziness for a clean UI; the underlying TCP/SSE connection close still releases everything when the client actually disconnects.