### PR TITLE
fix(systemd): Restart=always so clean SIGTERM doesn't strand the daemon

### DIFF
--- a/contrib/install/install.sh
+++ b/contrib/install/install.sh
@@ -124,7 +124,7 @@ After=default.target
 [Service]
 Type=simple
 ExecStart=$bin_path
-Restart=on-failure
+Restart=always
 RestartSec=2
 
 # kaeru-mcp tunables — uncomment and edit, then \`systemctl --user daemon-reload\`.

--- a/kaeru-mcp/contrib/systemd/kaeru-mcp.service
+++ b/kaeru-mcp/contrib/systemd/kaeru-mcp.service
@@ -21,7 +21,13 @@ After=default.target
 [Service]
 Type=simple
 ExecStart=%h/.cargo/bin/kaeru-mcp
-Restart=on-failure
+# Always restart, not just on-failure. A clean SIGTERM (e.g. from a desktop
+# session teardown or an accidental `systemctl --user stop`) would otherwise
+# leave the daemon down — and silent vault unavailability spreads quickly
+# because clients (Claude Code, Cursor) don't probe aggressively for
+# stopped services. To stop the daemon deliberately, use
+# `systemctl --user disable --now kaeru-mcp` or `mask`.
+Restart=always
 RestartSec=2
 
 # kaeru-mcp tunables — uncomment / adjust as needed.


### PR DESCRIPTION
## Summary

`Restart=on-failure` only re-runs the unit on non-zero exit or signal abort. A clean `SIGTERM` — desktop-session teardown, accidental `systemctl --user stop`, logout-on-tty events — is treated as deliberate and leaves the daemon down indefinitely. Clients (Claude Code, Cursor) then show `kaeru · ✘ failed` silently until someone tries a tool call.

Switch to `Restart=always` in both unit-file sources:
- `kaeru-mcp/contrib/systemd/kaeru-mcp.service` (manual install path)
- `contrib/install/install.sh` heredoc (prebuilt installer)

For a single-user dev daemon owning the vault this is the right default — bring it back regardless of how it stopped. To stop it deliberately the operator uses `systemctl --user disable --now kaeru-mcp` or `mask`, which is explicit and survives a daemon-reload.

## Observed today

```
07:40:08  SIGTERM  →  stopped
08:07:47  Started
08:08:02  SIGTERM  →  stopped     (15s uptime; cause unknown — possibly user-systemd lifecycle)
12:46:13  Started                  (~4.5h gap; came back at next login)
```

Cause of the SIGTERMs is still TBD on the affected machine, but the unit shouldn't be dependent on identifying every cause to stay up.

## Test plan

- [x] Edit unit file → `daemon-reload` → `restart` → daemon active
- [x] `kill -TERM <PID>` → 2 seconds later (RestartSec=2) systemd brings the unit back, PID changes, port listens, MCP `initialize` returns HTTP 200
- [x] Both unit-file sources updated identically

## Caveat

`Restart=always` will resist deliberate teardown via `systemctl --user stop`; operators must use `disable --now` or `mask` instead. The comment block in `kaeru-mcp.service` documents this.