### PR TITLE
fix(mcp): allow LAN Host headers via KAERU_MCP_ALLOWED_HOSTS

### DIFF
--- a/kaeru-mcp/README.md
+++ b/kaeru-mcp/README.md
@@ -76,6 +76,7 @@ Two layers, both env-driven:
 | Variable                     | Default       | Effect                                |
 |------------------------------|---------------|---------------------------------------|
 | `KAERU_MCP_LISTEN_ADDRESS`   | `127.0.0.1`   | Bind IPv4. `0.0.0.0` = LAN-exposed (no auth!). |
+| `KAERU_MCP_ALLOWED_HOSTS`    | *(empty)*     | Extra `Host` authorities to accept beyond loopback, comma-separated. **Required when binding to `0.0.0.0`** — see note below. |
 | `KAERU_MCP_LISTEN_PORT`      | `9876`        | TCP port.                             |
 | `KAERU_MCP_MOUNT_PATH`       | `/mcp`        | Streamable HTTP mount path (must start with `/`). |
 | `KAERU_MCP_SSE_PATH`         | `/sse`        | Legacy HTTP+SSE GET mount path.       |
@@ -168,6 +169,17 @@ with the inspector to see full param shapes.
 - **Auth.** None. `127.0.0.1` is fine for personal use; binding to
   `0.0.0.0` exposes the entire curator API to anyone who can reach
   the port. Add a reverse proxy if you need auth.
+- **LAN exposure needs `KAERU_MCP_ALLOWED_HOSTS`.** rmcp's Streamable
+  HTTP transport carries a DNS-rebinding guard that validates the
+  inbound `Host` header against an allow-list defaulting to loopback
+  only (`localhost`, `127.0.0.1`, `::1`). So `KAERU_MCP_LISTEN_ADDRESS=0.0.0.0`
+  on its own is **not enough** — a client connecting via the machine's
+  routable address gets `403 Forbidden: Host header is not allowed`,
+  and Claude Code mislabels that failed handshake as
+  *"Needs authentication"*. List the authority clients use (host or
+  `host:port`) so the guard lets it through:
+  `KAERU_MCP_ALLOWED_HOSTS=192.0.2.10:9876,kaeru.lan`. Loopback stays
+  allowed automatically.
 - **Updates.** After `cargo install --path kaeru-mcp`, restart the
   service so the new binary takes over: `systemctl --user restart
   kaeru-mcp` / `launchctl unload+load`.

--- a/kaeru-mcp/contrib/systemd/kaeru-mcp.service
+++ b/kaeru-mcp/contrib/systemd/kaeru-mcp.service
@@ -32,6 +32,12 @@ RestartSec=2
 
 # kaeru-mcp tunables — uncomment / adjust as needed.
 #Environment=KAERU_MCP_LISTEN_ADDRESS=127.0.0.1
+# When binding to 0.0.0.0 you MUST also whitelist the Host authority
+# clients use, or rmcp's DNS-rebinding guard returns 403 "Host header
+# is not allowed" (Claude Code shows it as "Needs authentication").
+# Loopback hosts stay allowed automatically. Comma-separated, host or
+# host:port, e.g. 192.0.2.10:9876,kaeru.lan.
+#Environment=KAERU_MCP_ALLOWED_HOSTS=
 #Environment=KAERU_MCP_LISTEN_PORT=9876
 #Environment=KAERU_MCP_MOUNT_PATH=/mcp
 #Environment=KAERU_MCP_LOG_LEVEL=info

--- a/kaeru-mcp/src/main.rs
+++ b/kaeru-mcp/src/main.rs
@@ -93,13 +93,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &mcp_config.sse_path,
         &mcp_config.messages_path,
     );
+    // rmcp's Streamable HTTP transport rejects any request whose `Host`
+    // header isn't in `allowed_hosts` (default: loopback only) as a
+    // DNS-rebinding guard — answering `403 Forbidden: Host header is not
+    // allowed`, which clients like Claude Code mislabel as "Needs
+    // authentication". When exposed on a routable address the operator
+    // must whitelist the host(s) clients use; we keep the loopback
+    // defaults so localhost sessions keep working regardless.
+    let default_config = StreamableHttpServerConfig::default();
+    let mut allowed_hosts = default_config.allowed_hosts.clone();
+    allowed_hosts.extend(
+        mcp_config
+            .allowed_hosts
+            .split(',')
+            .map(str::trim)
+            .filter(|h| !h.is_empty())
+            .map(str::to_string),
+    );
+    tracing::info!(?allowed_hosts, "host allow-list for inbound MCP requests");
+
     let service = StreamableHttpService::new(
         // Each MCP session reuses the same KaeruServer (and therefore
         // the same Arc<Store> / RocksDB lock); cloning the server is
         // cheap and shares state across sessions.
         move || Ok(server.clone()),
         Arc::new(session_manager),
-        StreamableHttpServerConfig::default()
+        default_config
+            .with_allowed_hosts(allowed_hosts)
             .with_cancellation_token(cancel.child_token()),
     );
 

--- a/kaeru-mcp/src/settings.rs
+++ b/kaeru-mcp/src/settings.rs
@@ -49,6 +49,19 @@ pub struct KaeruMcpConfig {
     #[serde(default = "default_messages_path")]
     pub messages_path: String,
 
+    /// Extra `Host` header authorities to accept, on top of the
+    /// loopback set (`localhost`, `127.0.0.1`, `::1`) that rmcp's
+    /// Streamable HTTP transport allows by default as a DNS-rebinding
+    /// guard. When binding to a routable address (`0.0.0.0`) you MUST
+    /// list the host(s) clients put in their `Host` header here —
+    /// otherwise rmcp answers `403 Forbidden: Host header is not
+    /// allowed` and clients like Claude Code surface it as
+    /// "Needs authentication". Comma-separated, with or without port,
+    /// e.g. `KAERU_MCP_ALLOWED_HOSTS=192.0.2.10:9876,kaeru.lan`.
+    /// Empty (default) keeps the loopback-only behaviour.
+    #[serde(default = "default_allowed_hosts")]
+    pub allowed_hosts: String,
+
     /// Tracing log level (`error`, `warn`, `info`, `debug`, `trace`).
     /// Logs go to stderr only because stdout is reserved when MCP
     /// servers run over stdio elsewhere — kaeru-mcp itself uses HTTP,
@@ -101,6 +114,10 @@ fn default_sse_path() -> String {
 
 fn default_messages_path() -> String {
     "/messages".to_string()
+}
+
+fn default_allowed_hosts() -> String {
+    String::new()
 }
 
 fn default_log_level() -> String {


### PR DESCRIPTION
## Problem

Binding the daemon to a routable address is documented as the way to share one vault across machines:

```
KAERU_MCP_LISTEN_ADDRESS=0.0.0.0
```

But on its own this does **not** work. A remote client connecting to `http://<lan-ip>:9876/mcp` gets:

```
HTTP/1.1 403 Forbidden
Forbidden: Host header is not allowed
```

In Claude Code the failed handshake surfaces as:

```
kaeru: http://<lan-ip>:9876/mcp (HTTP) - ! Needs authentication
```

…which is actively misleading, because **kaeru-mcp has no authentication at all**. Hours get burned chasing an auth/proxy problem that doesn't exist.

## Root cause

rmcp 1.6's Streamable HTTP transport carries a DNS-rebinding guard. `StreamableHttpServerConfig.allowed_hosts` validates the inbound `Host` header and defaults to **loopback only**:

```rust
// rmcp-1.6.0 streamable_http_server/tower.rs
allowed_hosts: vec!["localhost".into(), "127.0.0.1".into(), "::1".into()],
```

kaeru-mcp constructs the service with `StreamableHttpServerConfig::default()` and never extends that list:

```rust
StreamableHttpServerConfig::default()
    .with_cancellation_token(cancel.child_token())
```

So a client whose `Host` header is the machine's routable authority (e.g. `Host: 198.51.100.7:9876`) fails the allow-list and is rejected with 403 — regardless of `LISTEN_ADDRESS`. Loopback clients (`Host: localhost`) pass, which is why a local session connects and a LAN session does not. `LISTEN_ADDRESS=0.0.0.0` opens the socket but the Host guard still slams the door.

## Why this belongs upstream

- The daemon is **designed** to be a single-writer service that multiple machines connect to (`main.rs` module docs). LAN exposure is a first-class use case, and it's currently broken out of the box with no discoverable reason.
- The failure mode is opaque: a 403 mapped to "Needs authentication" in the most common client points every user at the wrong layer. The guard message never reaches the user.
- It's a one-line escape hatch in rmcp (`with_allowed_hosts`) that the embedding app must opt into — there is no way for an operator to fix this from config today.

## Fix

Add `KAERU_MCP_ALLOWED_HOSTS` (comma-separated host or `host:port` authorities). It is **merged onto** rmcp's loopback defaults via `.with_allowed_hosts(...)`, so:

- local/loopback sessions keep working unconditionally,
- operators whitelist the exact authority their LAN clients use,
- every other Host is still rejected — the rebinding guard stays intact.

The effective allow-list is logged at startup.

```ini
# systemd unit / env
KAERU_MCP_LISTEN_ADDRESS=0.0.0.0
KAERU_MCP_ALLOWED_HOSTS=198.51.100.7:9876,kaeru.lan
```

Empty (the default) preserves today's loopback-only behaviour, so this is non-breaking.

## Verification

New binary on a throwaway port with `KAERU_MCP_ALLOWED_HOSTS` set to the routable authority:

| Inbound `Host`        | Before | After |
|-----------------------|:------:|:-----:|
| routable LAN authority| 403    | 200   |
| `localhost`           | 200    | 200   |
| unlisted host         | 403    | 403   |

End-to-end: `claude mcp list` on a separate machine flips from `! Needs authentication` to `✔ Connected` once the LAN authority is whitelisted.

## Changes

- `kaeru-mcp/src/settings.rs` — new `KAERU_MCP_ALLOWED_HOSTS` field (optional, default empty).
- `kaeru-mcp/src/main.rs` — merge configured hosts onto rmcp's loopback defaults; log the effective list.
- `kaeru-mcp/README.md` — env table row + operational note explaining the guard and the "Needs authentication" mislabel.
- `kaeru-mcp/contrib/systemd/kaeru-mcp.service` — documented `KAERU_MCP_ALLOWED_HOSTS` entry (RFC 5737 example address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)