### PR TITLE
fix(migrate): backfill v0.2.0 schema onto pre-existing (v0.1.0) vaults

### DIFF
--- a/kaeru-core/src/migrate.rs
+++ b/kaeru-core/src/migrate.rs
@@ -50,10 +50,24 @@ struct Migration {
 
 /// The ordered migration registry. Append new migrations; never reorder or
 /// rename existing entries (the `name` is the journal key forever).
-const MIGRATIONS: &[Migration] = &[Migration {
-    name: "0001_chain_member",
-    up: m0001_chain_member,
-}];
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        name: "0001_chain_member",
+        up: m0001_chain_member,
+    },
+    Migration {
+        name: "0002_node_layer_visibility",
+        up: m0002_node_layer_visibility,
+    },
+    Migration {
+        name: "0003_edge_dst_store",
+        up: m0003_edge_dst_store,
+    },
+    Migration {
+        name: "0004_initiative",
+        up: m0004_initiative,
+    },
+];
 
 /// Applies pending migrations. `fresh` is `true` when the vault was just
 /// created at the latest schema this build; in that case every migration is
@@ -148,6 +162,24 @@ fn index_exists(db: &DbInstance, relation: &str, index: &str) -> Result<bool> {
     }))
 }
 
+/// Whether a stored `relation` carries a column named `column`. `::columns`
+/// lists one row per column with the column name in the first field.
+fn column_exists(db: &DbInstance, relation: &str, column: &str) -> Result<bool> {
+    let script = format!("::columns {relation}");
+    let rows = db.run_script(&script, BTreeMap::new(), ScriptMutability::Immutable)?;
+    Ok(rows
+        .rows
+        .iter()
+        .any(|r| r.first().and_then(|v| v.get_str()) == Some(column)))
+}
+
+/// Runs a mutating script with no params — a brevity wrapper for the many
+/// schema statements the migrations issue.
+fn run_mut(db: &DbInstance, script: &str) -> Result<()> {
+    db.run_script(script, BTreeMap::new(), ScriptMutability::Mutable)?;
+    Ok(())
+}
+
 // ── Migrations ──────────────────────────────────────────────────────────────
 
 /// `0001` — knowledge chains. Adds the `chain_member` relation and its
@@ -170,14 +202,198 @@ fn m0001_chain_member(db: &DbInstance) -> Result<()> {
     Ok(())
 }
 
+/// `0002` — memory layers + local/cloud visibility. Adds the `visibility` and
+/// `layer` columns (defaults `'local'` / `'warm'`) to `node` for vaults
+/// created before those features landed, plus the `by_layer` / `by_visibility`
+/// indexes.
+///
+/// Column backfill uses Cozo's `:replace`: read every stored row with the
+/// *old* column set, then `:replace` with the full v0.2.0 schema so the two
+/// new columns take their defaults. But Cozo refuses `:replace` on a relation
+/// that has indices attached, and `node` always carries some (`by_name`,
+/// `by_tier_type`, and the FTS indexes `ensure_fts_indexes` creates on every
+/// open). So the order is: drop every node index → `:replace` → recreate the
+/// full v0.2.0 index set. The `column_exists` guard is load-bearing: a second
+/// `:replace` against a relation that already has the columns would reset live
+/// values to the defaults. Idempotent: the drops/creates are existence-guarded.
+fn m0002_node_layer_visibility(db: &DbInstance) -> Result<()> {
+    if !column_exists(db, "node", "layer")? || !column_exists(db, "node", "visibility")? {
+        for idx in ["by_name", "by_tier_type", "by_layer", "by_visibility"] {
+            if index_exists(db, "node", idx)? {
+                run_mut(db, &format!("::index drop node:{idx}"))?;
+            }
+        }
+        for idx in ["fts_name", "fts_body"] {
+            if index_exists(db, "node", idx)? {
+                run_mut(db, &format!("::fts drop node:{idx}"))?;
+            }
+        }
+        run_mut(
+            db,
+            r#"
+            ?[id, validity, type, tier, name, body, tags, initiatives, properties] :=
+                *node{id, validity, type, tier, name, body, tags, initiatives, properties}
+            :replace node {
+                id: String,
+                validity: Validity default [floor_to_second(now()), true] =>
+                type: String,
+                tier: String,
+                name: String,
+                body: String?,
+                tags: [String]?,
+                initiatives: [String]?,
+                properties: Json?,
+                visibility: String default 'local',
+                layer: String default 'warm',
+            }
+            "#,
+        )?;
+    }
+    ensure_node_indices(db)?;
+    Ok(())
+}
+
+/// Recreates / ensures the full v0.2.0 index set on `node` (idempotent). The
+/// FTS statements mirror `store::FTS_INDEX_STATEMENTS` — duplicated here so the
+/// migration is self-contained and frozen at the schema it targets.
+fn ensure_node_indices(db: &DbInstance) -> Result<()> {
+    let regular = [
+        ("by_name", "::index create node:by_name { name }"),
+        (
+            "by_tier_type",
+            "::index create node:by_tier_type { tier, type }",
+        ),
+        ("by_layer", "::index create node:by_layer { layer }"),
+        (
+            "by_visibility",
+            "::index create node:by_visibility { visibility }",
+        ),
+    ];
+    for (name, stmt) in regular {
+        if !index_exists(db, "node", name)? {
+            run_mut(db, stmt)?;
+        }
+    }
+    let fts = [
+        (
+            "fts_name",
+            "::fts create node:fts_name { extractor: name, tokenizer: Simple, filters: [Lowercase] }",
+        ),
+        (
+            "fts_body",
+            "::fts create node:fts_body { extractor: body, extract_filter: !is_null(body), tokenizer: Simple, filters: [Lowercase] }",
+        ),
+    ];
+    for (name, stmt) in fts {
+        if !index_exists(db, "node", name)? {
+            run_mut(db, stmt)?;
+        }
+    }
+    Ok(())
+}
+
+/// `0003` — cloud soft-links. Adds the `dst_store` column (default `'local'`)
+/// to `edge` for vaults created before the local/cloud split, plus its index.
+/// Same drop-indices → `:replace` → recreate dance as
+/// [`m0002_node_layer_visibility`]; `edge` carries no FTS indexes.
+fn m0003_edge_dst_store(db: &DbInstance) -> Result<()> {
+    if !column_exists(db, "edge", "dst_store")? {
+        for idx in ["by_src", "by_dst", "by_edge_type", "by_dst_store"] {
+            if index_exists(db, "edge", idx)? {
+                run_mut(db, &format!("::index drop edge:{idx}"))?;
+            }
+        }
+        run_mut(
+            db,
+            r#"
+            ?[src, dst, edge_type, validity, weight, properties] :=
+                *edge{src, dst, edge_type, validity, weight, properties}
+            :replace edge {
+                src: String,
+                dst: String,
+                edge_type: String,
+                validity: Validity default [floor_to_second(now()), true] =>
+                weight: Float default 1.0,
+                properties: Json?,
+                dst_store: String default 'local',
+            }
+            "#,
+        )?;
+    }
+    let edge_indices = [
+        ("by_src", "::index create edge:by_src { src }"),
+        ("by_dst", "::index create edge:by_dst { dst }"),
+        (
+            "by_edge_type",
+            "::index create edge:by_edge_type { edge_type }",
+        ),
+        (
+            "by_dst_store",
+            "::index create edge:by_dst_store { dst_store }",
+        ),
+    ];
+    for (name, stmt) in edge_indices {
+        if !index_exists(db, "edge", name)? {
+            run_mut(db, stmt)?;
+        }
+    }
+    Ok(())
+}
+
+/// `0004` — sticky per-initiative share policy. Creates the `initiative`
+/// relation for vaults created before cloud sharing landed. Idempotent.
+fn m0004_initiative(db: &DbInstance) -> Result<()> {
+    if !relation_exists(db, "initiative")? {
+        db.run_script(
+            ":create initiative { name: String => share_policy: String default 'private', set_at: Float default now() }",
+            BTreeMap::new(),
+            ScriptMutability::Mutable,
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
 
     use cozo::{DbInstance, ScriptMutability};
 
-    use super::{index_exists, relation_exists, run_migrations};
+    use super::{column_exists, index_exists, relation_exists, run_migrations};
     use crate::store::Store;
+
+    /// A v0.1.0-shaped `node` (no `visibility` / `layer`), as a real legacy
+    /// vault carries it. The column-backfill migrations read this exact set.
+    const LEGACY_NODE: &str = r#"
+        :create node {
+            id: String,
+            validity: Validity default [floor_to_second(now()), true] =>
+            type: String,
+            tier: String,
+            name: String,
+            body: String?,
+            tags: [String]?,
+            initiatives: [String]?,
+            properties: Json?,
+        }
+    "#;
+
+    /// A v0.1.0-shaped `edge` (no `dst_store`).
+    const LEGACY_EDGE: &str = r#"
+        :create edge {
+            src: String,
+            dst: String,
+            edge_type: String,
+            validity: Validity default [floor_to_second(now()), true] =>
+            weight: Float default 1.0,
+            properties: Json?,
+        }
+    "#;
+
+    fn run(db: &DbInstance, script: &str) {
+        db.run_script(script, BTreeMap::new(), ScriptMutability::Mutable)
+            .unwrap();
+    }
 
     /// A fresh `Store` open stamps every registered migration as applied
     /// (baseline) — none should be left pending.
@@ -192,62 +408,156 @@ mod tests {
             .iter()
             .filter_map(|r| r.first().and_then(|v| v.get_str()).map(String::from))
             .collect();
-        assert!(
-            names.iter().any(|n| n == "0001_chain_member"),
-            "fresh vault baseline-stamps 0001; journal = {names:?}"
-        );
-        // chain_member already exists from the create-time schema.
+        for expected in [
+            "0001_chain_member",
+            "0002_node_layer_visibility",
+            "0003_edge_dst_store",
+            "0004_initiative",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "fresh vault baseline-stamps {expected}; journal = {names:?}"
+            );
+        }
+        // The create-time schema already carries everything the migrations add.
         assert!(relation_exists(store.db_ref(), "chain_member").unwrap());
+        assert!(relation_exists(store.db_ref(), "initiative").unwrap());
+        assert!(column_exists(store.db_ref(), "node", "layer").unwrap());
     }
 
-    /// Simulate a legacy vault: a bare Cozo db with only `node`, no
-    /// `migration_journal` and no `chain_member`. Running migrations against
-    /// it (fresh = false) must create the missing relation + index and stamp.
+    /// Simulate a v0.1.0 vault: `node` + `edge` in their pre-v0.2.0 shape, no
+    /// `migration_journal` / `chain_member` / `initiative`, and no
+    /// `layer`/`visibility`/`dst_store` columns. Running migrations (fresh =
+    /// false) must create the missing relations + indexes, backfill the new
+    /// columns from their defaults, preserve the existing rows, and stamp every
+    /// migration exactly once.
     #[test]
-    fn legacy_vault_runs_pending_migration() {
+    fn legacy_vault_runs_pending_migrations() {
         let db = DbInstance::new("mem", "", "").expect("mem db");
-        // Minimal pre-chains schema: just enough to look non-fresh.
-        db.run_script(
-            ":create node { id: String => name: String }",
-            BTreeMap::new(),
-            ScriptMutability::Mutable,
-        )
-        .unwrap();
+        run(&db, LEGACY_NODE);
+        run(&db, LEGACY_EDGE);
+        // One real node + one real edge so backfill operates on actual rows.
+        // Validity is supplied explicitly (as kaeru's own writes do) — omitting
+        // it would force the `now()`-based default into a constant rule.
+        run(
+            &db,
+            "?[id, validity, type, tier, name, body, tags, initiatives, properties] <- \
+             [['n1', [1700000000.0, true], 'reference', 'archival', 'legacy', null, null, null, null]] \
+             :put node {id, validity => type, tier, name, body, tags, initiatives, properties}",
+        );
+        run(
+            &db,
+            "?[src, dst, edge_type, validity, weight, properties] <- \
+             [['n1', 'n1', 'relates_to', [1700000000.0, true], 1.0, null]] \
+             :put edge {src, dst, edge_type, validity => weight, properties}",
+        );
+
         assert!(
             !relation_exists(&db, "chain_member").unwrap(),
             "absent before"
         );
+        assert!(
+            !column_exists(&db, "node", "layer").unwrap(),
+            "no layer before"
+        );
+        assert!(
+            !column_exists(&db, "edge", "dst_store").unwrap(),
+            "no dst_store before"
+        );
 
         run_migrations(&db, false).expect("migrate legacy");
 
+        // 0001 / 0004: new relations + indexes.
         assert!(
             relation_exists(&db, "chain_member").unwrap(),
-            "created by 0001"
+            "0001 chain_member"
         );
         assert!(
             index_exists(&db, "chain_member", "by_node").unwrap(),
-            "index created"
+            "0001 index"
+        );
+        assert!(
+            relation_exists(&db, "initiative").unwrap(),
+            "0004 initiative"
+        );
+        // 0002 / 0003: backfilled columns + indexes.
+        assert!(
+            column_exists(&db, "node", "layer").unwrap(),
+            "0002 node.layer"
+        );
+        assert!(
+            column_exists(&db, "node", "visibility").unwrap(),
+            "0002 node.visibility"
+        );
+        assert!(
+            index_exists(&db, "node", "by_layer").unwrap(),
+            "0002 by_layer"
+        );
+        assert!(
+            column_exists(&db, "edge", "dst_store").unwrap(),
+            "0003 edge.dst_store"
         );
 
-        let journal = db
+        // Existing row survived and picked up the schema defaults.
+        let node = db
             .run_script(
-                "?[name] := *migration_journal{name}",
+                "?[name, layer, visibility] := *node{id, name, layer, visibility @ 'NOW'}, id = 'n1'",
                 BTreeMap::new(),
                 ScriptMutability::Immutable,
             )
             .unwrap();
-        assert_eq!(journal.rows.len(), 1, "0001 stamped exactly once");
+        assert_eq!(node.rows.len(), 1, "n1 preserved");
+        assert_eq!(
+            node.rows[0][1].get_str(),
+            Some("warm"),
+            "layer default backfilled"
+        );
+        assert_eq!(
+            node.rows[0][2].get_str(),
+            Some("local"),
+            "visibility default backfilled"
+        );
+        let edge = db
+            .run_script(
+                "?[dst_store] := *edge{src, dst_store @ 'NOW'}, src = 'n1'",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
+            .unwrap();
+        assert_eq!(
+            edge.rows[0][0].get_str(),
+            Some("local"),
+            "dst_store default backfilled"
+        );
 
-        // Idempotent: a second pass is a no-op and does not error.
-        run_migrations(&db, false).expect("re-run is safe");
-        let journal2 = db
-            .run_script(
+        let count = |db: &DbInstance| {
+            db.run_script(
                 "?[name] := *migration_journal{name}",
                 BTreeMap::new(),
                 ScriptMutability::Immutable,
             )
+            .unwrap()
+            .rows
+            .len()
+        };
+        assert_eq!(count(&db), 4, "all four migrations stamped once");
+
+        // Idempotent: a second pass is a no-op that must NOT reset the
+        // backfilled values (the column_exists guard prevents a re-`:replace`).
+        run_migrations(&db, false).expect("re-run is safe");
+        assert_eq!(count(&db), 4, "still four after re-run");
+        let again = db
+            .run_script(
+                "?[layer] := *node{id, layer @ 'NOW'}, id = 'n1'",
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+            )
             .unwrap();
-        assert_eq!(journal2.rows.len(), 1, "still stamped once");
+        assert_eq!(
+            again.rows[0][0].get_str(),
+            Some("warm"),
+            "value preserved across re-run"
+        );
     }
 
     /// The real upgrade scenario through RocksDB: a disk vault is created with
@@ -263,26 +573,26 @@ mod tests {
 
         let path = env::temp_dir().join(format!("kaeru-mig-disk-{}", new_node_id()));
 
-        // First open: hand-build a legacy-shaped vault directly on the engine,
-        // bypassing the full bootstrap so `chain_member` is genuinely absent.
+        // First open: hand-build a v0.1.0-shaped vault directly on the engine,
+        // bypassing the full bootstrap so the v0.2.0 schema is genuinely absent.
         {
             let db = DbInstance::new("rocksdb", path.to_string_lossy().as_ref(), "")
                 .expect("open rocksdb");
-            db.run_script(
-                ":create node { id: String => name: String, body: String? }",
-                BTreeMap::new(),
-                ScriptMutability::Mutable,
-            )
-            .unwrap();
-            db.run_script(
-                "?[id, name, body] <- [['n1', 'legacy', null]] :put node {id => name, body}",
-                BTreeMap::new(),
-                ScriptMutability::Mutable,
-            )
-            .unwrap();
+            run(&db, LEGACY_NODE);
+            run(&db, LEGACY_EDGE);
+            run(
+                &db,
+                "?[id, validity, type, tier, name, body, tags, initiatives, properties] <- \
+                 [['n1', [1700000000.0, true], 'reference', 'archival', 'legacy', null, null, null, null]] \
+                 :put node {id, validity => type, tier, name, body, tags, initiatives, properties}",
+            );
             assert!(
                 !relation_exists(&db, "chain_member").unwrap(),
                 "absent at create"
+            );
+            assert!(
+                !column_exists(&db, "node", "layer").unwrap(),
+                "no layer at create"
             );
         }
 
@@ -294,10 +604,19 @@ mod tests {
                 relation_exists(store.db_ref(), "chain_member").unwrap(),
                 "0001 created chain_member on reopen"
             );
+            assert!(
+                column_exists(store.db_ref(), "node", "layer").unwrap(),
+                "0002 backfilled node.layer on reopen"
+            );
             let preserved = store
-                .run_read("?[name] := *node{id, name}, id = 'n1'")
+                .run_read("?[name, layer] := *node{id, name, layer @ 'NOW'}, id = 'n1'")
                 .unwrap();
             assert_eq!(preserved.rows.len(), 1, "pre-existing node row survived");
+            assert_eq!(
+                preserved.rows[0][1].get_str(),
+                Some("warm"),
+                "row backfilled with default layer"
+            );
         }
 
         let _ = fs::remove_dir_all(&path);


### PR DESCRIPTION
## Problem

Upgrading an existing **v0.1.0** vault to **v0.2.0** leaves it broken. The migration registry in `kaeru-core/src/migrate.rs` ships only `0001_chain_member`, but v0.2.0 added more to `SCHEMA_STATEMENTS` — which only runs for **fresh** vaults (`bootstrap_schema` skips it when `node` already exists). So an upgraded vault never gains:

| Addition | Kind |
|---|---|
| `node.visibility` `default 'local'` | column |
| `node.layer` `default 'warm'` | column |
| `edge.dst_store` `default 'local'` | column |
| `initiative { name => share_policy, set_at }` | relation |
| `node:by_layer`, `node:by_visibility`, `edge:by_dst_store` | indexes |

Any read/write that names `layer`/`visibility`/`dst_store` then fails with `eval::named_field_not_found`. In practice this breaks `awake` (its `recall_by_layer` filters `layer = $layer`) and `surface`, and — because every mutation writes an `audit_event` carrying `layer`, and `episode`/`jot`/`cite` set it too — it breaks **writes** as well. The vault is effectively read- and write-frozen after upgrade.

Reproduce: create a vault on v0.1.0, open it with v0.2.0, call `awake` →

```
× stored relation 'node' does not have field 'layer'
```

## Fix

Three idempotent, forward-only migrations appended to the registry:

- **`0002_node_layer_visibility`** — backfill `node.layer`/`node.visibility`; add `by_layer`/`by_visibility`.
- **`0003_edge_dst_store`** — backfill `edge.dst_store`; add `by_dst_store`.
- **`0004_initiative`** — create the `initiative` relation.

### Note on the `:replace` pattern

The module doc describes adding a column via `:replace`, but Cozo **refuses `:replace` on a relation with indices attached**, and `node`/`edge` always carry some (`by_name`, `by_tier_type`, plus the FTS indexes `ensure_fts_indexes` (re)creates on every open). So each column migration **drops the relation's indices → `:replace` (new columns take their defaults) → recreates the full v0.2.0 index set** (FTS statements mirror `store::FTS_INDEX_STATEMENTS`). A `column_exists` guard keeps it idempotent — a second `:replace` would reset live values back to defaults.

## Tests

- `fresh_open_baseline_stamps_all_migrations` — now asserts all four migrations baseline-stamp, and that `initiative`/`node.layer` exist on a fresh vault.
- `legacy_vault_runs_pending_migrations` (renamed) — builds realistic v0.1.0-shaped `node` + `edge` with real rows; asserts columns/relations/indexes are created, rows + bitemporal history survive, defaults backfill, and a second pass neither re-stamps nor clobbers values.
- `disk_legacy_vault_upgrades_on_reopen` — the real RocksDB upgrade path; now asserts the on-disk row is backfilled to `layer='warm'` on reopen.

`cargo test -p kaeru-core` → 69 passed. Verified end-to-end against a real upgraded vault: `awake`/`surface` recover, all rows carry the backfilled `warm` layer, data intact, writes work again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)