### PR TITLE
fix(mcp): bound graceful shutdown so SIGTERM doesn't hang 90s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ config = "0.14"
 # not available: it tied each session to its own subprocess and made
 # multi-session use impossible (RocksDB is single-writer).
 rmcp = { version = "1.6", features = ["server", "transport-streamable-http-server", "macros"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "net"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "net", "time"] }
 tokio-util = "0.7"
 tokio-stream = "0.1"
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json", "query"] }

--- a/kaeru-mcp/src/main.rs
+++ b/kaeru-mcp/src/main.rs
@@ -27,6 +27,7 @@ mod utils;
 
 use std::collections::HashMap;
 use std::error::Error;
+use std::future::IntoFuture;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -134,6 +135,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let sse_router = sse::router(
         server.clone(),
+        cancel.child_token(),
         &mcp_config.sse_path,
         &mcp_config.messages_path,
     );
@@ -211,13 +213,36 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "kaeru-mcp listening — point MCP clients here"
     );
 
-    axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown(cancel))
-        .await?;
-
-    tracing::info!("kaeru-mcp stopped");
+    // Serve with graceful shutdown, but bound the drain: long-lived MCP
+    // streams (the streamable-HTTP GET channel, legacy SSE) don't always
+    // close the instant their sessions are cancelled, so an unbounded
+    // graceful shutdown can block until systemd's `TimeoutStopSec` (90s by
+    // default) SIGKILLs the daemon. Once shutdown is requested we give
+    // in-flight work a short grace window, then force the process to exit.
+    let graceful = axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown(cancel.clone()))
+        .into_future();
+    tokio::pin!(graceful);
+    tokio::select! {
+        res = &mut graceful => {
+            res?;
+            tracing::info!("kaeru-mcp stopped");
+        }
+        () = grace_deadline(cancel, SHUTDOWN_GRACE) => {
+            tracing::warn!(
+                grace_secs = SHUTDOWN_GRACE.as_secs(),
+                "shutdown grace window elapsed with connections still open; forcing exit"
+            );
+        }
+    }
     Ok(())
 }
+
+/// How long graceful shutdown is allowed to drain in-flight connections
+/// after a stop is requested before the daemon forces exit. Kept well under
+/// systemd's default `TimeoutStopSec` (90s) so a clean stop never escalates
+/// to SIGKILL.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
 
 /// Waits for either Ctrl-C or SIGTERM, then cancels the rmcp service
 /// token so in-flight sessions wind down cleanly. SIGTERM coverage is
@@ -245,4 +270,12 @@ async fn shutdown(cancel: CancellationToken) {
         _ = terminate => tracing::info!("SIGTERM received"),
     }
     cancel.cancel();
+}
+
+/// Resolves once shutdown has been requested (`cancel` fired) **and** the
+/// grace window has elapsed — the backstop that bounds how long the daemon
+/// waits for stubborn long-lived connections to drain.
+async fn grace_deadline(cancel: CancellationToken, grace: Duration) {
+    cancel.cancelled().await;
+    tokio::time::sleep(grace).await;
 }

--- a/kaeru-mcp/src/sse.rs
+++ b/kaeru-mcp/src/sse.rs
@@ -36,6 +36,7 @@ use serde::Deserialize;
 use tokio::sync::{Mutex, mpsc};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::{Stream, StreamExt};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::server::KaeruServer;
@@ -54,6 +55,7 @@ struct SseState {
     server: KaeruServer,
     sessions: Arc<Mutex<HashMap<Uuid, mpsc::Sender<RxJsonRpcMessage<RoleServer>>>>>,
     messages_path: Arc<str>,
+    cancel: CancellationToken,
 }
 
 /// Build an axum router exposing the legacy HTTP+SSE MCP transport.
@@ -61,11 +63,20 @@ struct SseState {
 /// Two routes are added:
 /// - `GET  <sse_path>`     — opens the SSE stream, emits the endpoint event.
 /// - `POST <messages_path>` — JSON-RPC request entry-point.
-pub fn router(server: KaeruServer, sse_path: &str, messages_path: &str) -> Router {
+///
+/// `cancel` is the daemon's shutdown token; open SSE streams end when it
+/// fires so graceful shutdown isn't blocked by these long-lived responses.
+pub fn router(
+    server: KaeruServer,
+    cancel: CancellationToken,
+    sse_path: &str,
+    messages_path: &str,
+) -> Router {
     let state = SseState {
         server,
         sessions: Arc::new(Mutex::new(HashMap::new())),
         messages_path: Arc::from(messages_path),
+        cancel,
     };
     Router::new()
         .route(sse_path, get(open_stream))
@@ -90,18 +101,30 @@ async fn open_stream(
 
     let server = state.server.clone();
     let sessions = state.sessions.clone();
+    let cancel = state.cancel.clone();
     tokio::spawn(async move {
-        match server.serve(transport).await {
-            Ok(running) => match running.waiting().await {
-                Ok(reason) => {
-                    tracing::debug!(%session_id, ?reason, "sse session finished");
-                }
+        let session = async {
+            match server.serve(transport).await {
+                Ok(running) => match running.waiting().await {
+                    Ok(reason) => {
+                        tracing::debug!(%session_id, ?reason, "sse session finished");
+                    }
+                    Err(e) => {
+                        tracing::warn!(%session_id, error = %e, "sse session ended with error");
+                    }
+                },
                 Err(e) => {
-                    tracing::warn!(%session_id, error = %e, "sse session ended with error");
+                    tracing::warn!(%session_id, error = %e, "sse session failed to initialize");
                 }
-            },
-            Err(e) => {
-                tracing::warn!(%session_id, error = %e, "sse session failed to initialize");
+            }
+        };
+        // On daemon shutdown, drop the session future — that releases the
+        // transport (and its SSE sender), ending the client's stream so
+        // graceful shutdown isn't blocked by this long-lived response.
+        tokio::select! {
+            () = session => {}
+            () = cancel.cancelled() => {
+                tracing::debug!(%session_id, "sse session ended by daemon shutdown");
             }
         }
         sessions.lock().await.remove(&session_id);


### PR DESCRIPTION
## Problem

Stopping `kaeru-mcp` under systemd takes **~90 s and ends in SIGKILL** on every restart/reboot:

```
SIGTERM received
kaeru-mcp.service: State 'stop-sigterm' timed out. Killing.
kaeru-mcp.service: Killing process … with signal SIGKILL
kaeru-mcp.service: Failed with result 'timeout'.
```

`axum::serve(...).with_graceful_shutdown(shutdown(cancel))` (main.rs) waits for every in-flight connection to drain before returning. On SIGTERM the handler logs and calls `cancel.cancel()`, but the **long-lived MCP streams don't close**:

- the legacy **SSE** GET stream (`sse.rs::open_stream`) is never wired to the cancellation token, so it lives until the *client* disconnects;
- the streamable-HTTP GET channel similarly stays open when its session is cancelled.

So the drain blocks until systemd's default `TimeoutStopSec` (90 s) escalates to SIGKILL. It's benign — SIGTERM is caught, nothing is mid-write, and the Cozo/RocksDB vault is durable — but it makes every stop slow and logs a `timeout` failure (and drags out logout/reboot, since the user unit holds the session 90 s).

This is independent of the binary version; it's the shutdown design.

## Fix

Two parts:

1. **Bound the drain** (`main.rs`). After a stop is requested (`cancel` fired), race the graceful-shutdown future against a short grace deadline (`SHUTDOWN_GRACE = 3s`); if it overruns, log and force exit. A clean stop then stays well under `TimeoutStopSec`, so systemd never SIGKILLs.
2. **End SSE streams on shutdown** (`sse.rs`). Thread the daemon's cancellation token into the SSE router and `select!` the per-session task against `cancel.cancelled()`. Cancellation drops the session future → drops the transport (and its SSE sender) → the client's stream ends, letting graceful shutdown complete on its own rather than relying on the deadline.

Adds the `time` feature to `tokio` (for the grace `sleep`).

## Verification

Built and deployed under the systemd user unit. Stopping the **fixed** daemon:

```
20:41:48  SIGTERM received
20:41:48  kaeru-mcp stopped          ← graceful drain completed, same second
20:41:48  Stopped kaeru-mcp …        ← clean: no "timed out. Killing", no SIGKILL
```

vs. the prior binary immediately above it in the same journal: `SIGTERM received` → 90 s → `timed out. Killing` → SIGKILL. The fixed daemon shuts down in **under a second**, cleanly; the 3 s deadline is the backstop for the streamable-HTTP case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)