### PR TITLE
docs: move galaxy GIF hero to the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Inspired by the LLM-wiki pattern (Karpathy, gist `442a6bf555914893e9891c11519de9
 
 Name: 蛙 (*kaeru*, "frog"; homophonic with 帰る "to return" and 変える "to change") — the agent that returns, recalls, and reshapes.
 
-![A kaeru vault rendered as a knowledge galaxy by kaeru-viz](kaeru-viz/screenshot.png)
+![A kaeru vault rendered as a live knowledge galaxy by kaeru-viz](kaeru-viz/galaxy.gif)
 
 <sub>A kaeru vault rendered by [`kaeru-viz`](kaeru-viz/) — one cluster per initiative, nodes sized by memory layer, with reasoning-chain replay and a time-lapse of how the knowledge grew.</sub>
 
 ## Overview
+
+![A kaeru vault rendered as a knowledge galaxy by kaeru-viz](kaeru-viz/screenshot.png)
 
 `kaeru` is built around a typed property graph stored in CozoDB. Two tiers, biological analogy:
 

--- a/kaeru-viz/README.md
+++ b/kaeru-viz/README.md
@@ -10,10 +10,6 @@ It renders the JSON served by the kaeru-mcp daemon at `GET /graph.json`
 sized by memory layer (Core glows largest), edges coloured by type and weighted
 by strength, plus a time-lapse of the months of accumulation.
 
-![kaeru-viz — a live knowledge galaxy: project clusters, cross-project bridges, and a months-long time-lapse](galaxy.gif)
-
-## Overview
-
 ![kaeru-viz — a vault rendered as a knowledge galaxy](screenshot.png)
 
 ## Data


### PR DESCRIPTION
Follow-up to #15. The animated galaxy GIF was merged into **kaeru-viz/README.md**, but it belongs in the repo's **top-level README**.

- Root `README.md`: use `kaeru-viz/galaxy.gif` as the hero (was `screenshot.png`); move the static screenshot under the existing **Overview** section.
- `kaeru-viz/README.md`: revert to its original static-screenshot hero.

The `galaxy.gif` asset (added in #15) is reused as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)