### PR TITLE
feat(mcp): nudge link + chain at point of capture

### DIFF
--- a/kaeru-mcp/src/server.rs
+++ b/kaeru-mcp/src/server.rs
@@ -685,7 +685,15 @@ impl ServerHandler for KaeruServer {
               immediately `search` for related existing nodes and `link` them. Isolated nodes are islands \
               that only exact-name lookups will find. One `link` call per related node. Edge types: \
               `causal` (A causes B), `derived-from` (B is a refinement of A), `refers-to` (A mentions B, \
-              default), `part-of`, `blocks`, `targets`, `contradicts`. \
+              default), `part-of`, `blocks`, `targets`, `contradicts`. Mark the key reasoning links \
+              `strong=true` (weight 1.0) so chains prefer them. \
+              \
+              THEN MATERIALISE THE REASONING TRAIL — linking is not the end. Once a line of work runs from \
+              a starting observation to a decision or outcome, call `chain(from, to)` to save that ordered \
+              path as a named, replayable trail, and revisit it with `chains` / `read_chain`. A graph of \
+              links is navigable; a chain is the explicit \"state → reasoning → decision\" story a fresh \
+              agent reads to understand WHY, not just WHAT. Don't stop at isolated captures — link every \
+              node, and chain every reasoning run. \
               \
               LANGUAGE: store and search in the user's NATIVE language. Don't translate Russian to English on \
               capture; don't translate Russian queries to English on lookup. Each node carries a `lang:*` tag \

--- a/kaeru-mcp/src/tools/capture.rs
+++ b/kaeru-mcp/src/tools/capture.rs
@@ -14,8 +14,8 @@ use rmcp::model::CallToolResult;
 use crate::cloud_client::CloudClient;
 use crate::tools::cloud::push_to_cloud;
 use crate::utils::{
-    parse_layer, parse_wants_shared, resolve_name, resolve_name_or_id, text, to_mcp,
-    with_initiative,
+    parse_layer, parse_wants_shared, resolve_name, resolve_name_or_id, text, text_with_nudge,
+    to_mcp, with_initiative,
 };
 
 /// When `want_share`, attempts to push the just-created node `id` to the
@@ -75,7 +75,7 @@ pub async fn episode(
     })?;
     let mut msg = format!("wrote episode: {name} — {id}");
     maybe_share(store, cloud, &id, initiative, want_share, &mut msg).await?;
-    Ok(text(&msg))
+    Ok(text_with_nudge(&msg))
 }
 
 pub async fn jot(
@@ -98,7 +98,7 @@ pub async fn jot(
         .unwrap_or_default();
     let mut msg = format!("jotted: {name} — {id}");
     maybe_share(store, cloud, &id, initiative, want_share, &mut msg).await?;
-    Ok(text(&msg))
+    Ok(text_with_nudge(&msg))
 }
 
 pub fn link(
@@ -193,5 +193,5 @@ pub async fn cite(
         None => format!("cited: {name} — {id}"),
     };
     maybe_share(store, cloud, &id, initiative, want_share, &mut msg).await?;
-    Ok(text(&msg))
+    Ok(text_with_nudge(&msg))
 }

--- a/kaeru-mcp/src/tools/hypothesis.rs
+++ b/kaeru-mcp/src/tools/hypothesis.rs
@@ -4,7 +4,9 @@ use kaeru_core::{EdgeType, HypothesisStatus, Store};
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
 
-use crate::utils::{derive_auto_name, parse_layer, resolve_name, text, to_mcp, with_initiative};
+use crate::utils::{
+    derive_auto_name, parse_layer, resolve_name, text, text_with_nudge, to_mcp, with_initiative,
+};
 
 pub fn claim(
     store: &Store,
@@ -22,7 +24,7 @@ pub fn claim(
             let target = resolve_name(store, a)?;
             kaeru_core::link(store, &id, &target, EdgeType::RefersTo).map_err(to_mcp)?;
         }
-        Ok(text(&format!("claimed: {auto_name} — {id}")))
+        Ok(text_with_nudge(&format!("claimed: {auto_name} — {id}")))
     })
 }
 

--- a/kaeru-mcp/src/tools/task.rs
+++ b/kaeru-mcp/src/tools/task.rs
@@ -5,7 +5,8 @@ use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
 
 use crate::utils::{
-    parse_due_to_iso, parse_layer, resolve_name_or_id, text, to_mcp, with_initiative,
+    parse_due_to_iso, parse_layer, resolve_name_or_id, text, text_with_nudge, to_mcp,
+    with_initiative,
 };
 
 pub fn task(
@@ -32,7 +33,7 @@ pub fn task(
             Some(d) => format!("task: {name} (due {d}) — {id}"),
             None => format!("task: {name} — {id}"),
         };
-        Ok(text(&label))
+        Ok(text_with_nudge(&label))
     })
 }
 

--- a/kaeru-mcp/src/utils.rs
+++ b/kaeru-mcp/src/utils.rs
@@ -25,6 +25,20 @@ pub fn text(s: &str) -> CallToolResult {
     CallToolResult::success(vec![Content::text(s)])
 }
 
+/// One-line nudge appended to every capture result. A fresh node is an
+/// island until it's connected — this reminds the agent, at the moment of
+/// capture, to `link` it and (when a line of work runs start→decision) save
+/// the reasoning trail with `chain`. A hint in the result, not a gate: the
+/// substrate is a facilitator, not an enforcer.
+pub const CAPTURE_NUDGE: &str = "\n↳ now connect it: `search` related → `link` \
+     (strong=true for key edges); when a line of work runs start→decision/outcome, \
+     `chain(from, to)` to save the reasoning trail. Don't leave it an island.";
+
+/// Appends [`CAPTURE_NUDGE`] to a capture message and renders it.
+pub fn text_with_nudge(s: &str) -> CallToolResult {
+    text(&format!("{s}{CAPTURE_NUDGE}"))
+}
+
 pub fn to_mcp(e: Error) -> McpError {
     McpError::internal_error(e.to_string(), None)
 }


### PR DESCRIPTION
## Why

Reasoning chains (`chain` / `chains` / `read_chain`) are one of kaeru's strongest features, yet in practice the least used — the agent has to be reminded by hand. The rule belongs where it actually applies: chains are built **at every capture, throughout the session**, so the reminder has to land at the moment of capture, not once up front.

Both changes are **hints, not gates** (`facilitator, not enforcer`, per CLAUDE.md: don't introduce required call sequences).

## What changes

**1. MCP server instructions** (`server.rs`, `.with_instructions`)
The `ALWAYS LINK AFTER CAPTURING` block mentioned only `link` — never `chain`. Added a `THEN MATERIALISE THE REASONING TRAIL` step (call `chain(from, to)`, revisit with `chains` / `read_chain`) plus the `strong=true` tip for key reasoning edges. This travels with every client (Claude Code, opencode, rig) — one source of truth.

**2. A nudge in the capture results**
`episode` / `jot` / `cite` / `claim` / `task` returned a flat `wrote … — {id}` line. They now append a one-line `CAPTURE_NUDGE` (`utils.rs`): `search` related → `link` → `chain`. It lands at the moment of action, every time — point-of-use beats start-of-session. `link` / `unlink` / `reweight` / `done` are left untouched — they don't create a knowledge node.

## Verification

- `cargo check -p kaeru-mcp` — clean
- `cargo test -p kaeru-mcp` — 9 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)