### PR TITLE
feat: surface node assertion time in reads

### DIFF
--- a/kaeru-core/src/graph/temporal.rs
+++ b/kaeru-core/src/graph/temporal.rs
@@ -27,6 +27,10 @@ pub struct NodeSnapshot {
     pub tags: Vec<String>,
     pub layer: String,
     pub visibility: String,
+    /// Unix seconds of the validity that was in effect at the read time —
+    /// i.e. when this version of the node was asserted. `None` if the
+    /// substrate returned no parseable validity.
+    pub ts: Option<f64>,
 }
 
 /// One row in a node's bi-temporal history, ordered by validity.
@@ -49,8 +53,8 @@ pub fn at(store: &Store, id: &NodeId, at_seconds: f64) -> Result<Option<NodeSnap
 
     let script = format!(
         r#"
-        ?[type, tier, name, body, tags, layer, visibility] :=
-            *node{{id, type, tier, name, body, tags, layer, visibility @ {at_seconds}}}, id = $id
+        ?[type, tier, name, body, tags, layer, visibility, validity] :=
+            *node{{id, type, tier, name, body, tags, layer, visibility, validity @ {at_seconds}}}, id = $id
         "#
     );
     let rows = store
@@ -80,6 +84,7 @@ pub fn at(store: &Store, id: &NodeId, at_seconds: f64) -> Result<Option<NodeSnap
                 .and_then(|v| v.get_str())
                 .map(String::from)
                 .unwrap_or_else(|| "local".to_string()),
+            ts: validity_seconds(row.get(7)),
         }
     });
     Ok(result)
@@ -140,6 +145,20 @@ pub fn history(store: &Store, id: &NodeId) -> Result<Vec<Revision>> {
 /// seconds-since-epoch on the kaeru side. Cozo's own `current_validity()`
 /// (used by `@ 'NOW'`) writes microseconds; we don't read that path back
 /// out, so this parser only handles the seconds-scale values we wrote.
+/// Best-effort read of a validity column into Unix seconds. Returns `Some`
+/// only for an **asserted** `Validity`; `None` for a retraction, a missing
+/// column, or any non-Validity value — so a caller can pass a result row's
+/// last column without first knowing whether it carries validity.
+pub(crate) fn validity_seconds(dv: Option<&DataValue>) -> Option<f64> {
+    match dv {
+        Some(DataValue::Validity(Validity {
+            timestamp,
+            is_assert,
+        })) if is_assert.0 => Some(timestamp.0.0 as f64),
+        _ => None,
+    }
+}
+
 pub(crate) fn parse_validity(dv: Option<&DataValue>) -> Result<(f64, bool)> {
     let dv = dv.ok_or_else(|| Error::Substrate("missing validity column".to_string()))?;
     let DataValue::Validity(Validity {
@@ -153,4 +172,33 @@ pub(crate) fn parse_validity(dv: Option<&DataValue>) -> Result<(f64, bool)> {
     };
     let seconds = timestamp.0.0 as f64;
     Ok((seconds, is_assert.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::at;
+    use crate::store::Store;
+    use crate::{EpisodeKind, Significance, node_brief_by_id, write_episode};
+
+    /// A freshly written node exposes its assertion time both through `at`
+    /// (the full snapshot) and through a `NodeBrief` — in Unix **seconds**,
+    /// not Cozo's microsecond `@ 'NOW'` scale — and the two agree.
+    #[test]
+    fn at_and_brief_expose_assertion_ts_in_seconds() {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("t");
+        let id =
+            write_episode(&store, EpisodeKind::Observation, Significance::Low, "n", "body").unwrap();
+
+        // Read as-of the far future so the still-valid asserted row is seen.
+        let snap = at(&store, &id, 9_999_999_999.0).unwrap().expect("snapshot");
+        let ts = snap.ts.expect("snapshot carries a validity ts");
+        assert!(
+            (1_700_000_000.0..5_000_000_000.0).contains(&ts),
+            "ts is Unix seconds, not micros; got {ts}"
+        );
+
+        let brief = node_brief_by_id(&store, &id).unwrap().expect("brief");
+        assert_eq!(brief.ts, Some(ts), "brief ts matches snapshot ts");
+    }
 }

--- a/kaeru-core/src/recall/by_name.rs
+++ b/kaeru-core/src/recall/by_name.rs
@@ -67,7 +67,7 @@ pub fn node_brief_by_id(store: &Store, id: &NodeId) -> Result<Option<NodeBrief>>
     params.insert("id".to_string(), DataValue::Str(id.clone().into()));
 
     let script = r#"
-        ?[id, type, name, body] := *node{id, type, name, body @ 'NOW'}, id = $id
+        ?[id, type, name, body, validity] := *node{id, type, name, body, validity @ 'NOW'}, id = $id
     "#;
     let rows = store
         .db_ref()

--- a/kaeru-core/src/recall/initiatives.rs
+++ b/kaeru-core/src/recall/initiatives.rs
@@ -41,9 +41,9 @@ pub fn nodes_in_initiative(store: &Store, initiative: &str) -> Result<Vec<NodeBr
     params.insert("init".to_string(), DataValue::Str(initiative.into()));
 
     let script = r#"
-        ?[id, type, name, body] := *node_initiative{initiative, node_id: id},
+        ?[id, type, name, body, validity] := *node_initiative{initiative, node_id: id},
                                    initiative = $init,
-                                   *node{id, type, name, body @ 'NOW'},
+                                   *node{id, type, name, body, validity @ 'NOW'},
                                    type != 'audit_event'
     "#;
     let rows = store

--- a/kaeru-core/src/recall/mod.rs
+++ b/kaeru-core/src/recall/mod.rs
@@ -7,6 +7,7 @@
 use cozo::DataValue;
 
 use crate::graph::NodeId;
+use crate::graph::temporal::validity_seconds;
 
 pub mod between;
 pub mod by_name;
@@ -49,6 +50,10 @@ pub struct NodeBrief {
     pub node_type: String,
     pub name: String,
     pub body_excerpt: Option<String>,
+    /// Unix seconds of the node's latest assertion (created / last revised),
+    /// for chronological display. `Some` when the producing query selects
+    /// `validity` as its **last** column; `None` otherwise.
+    pub ts: Option<f64>,
 }
 
 /// Full node record at NOW — every field a sharing / ingest path needs,
@@ -69,9 +74,11 @@ pub struct NodeFull {
     pub layer: String,
 }
 
-/// Parses a Cozo result row of `[id, type, name, body, ...]` into a
-/// `NodeBrief`, truncating `body` to `excerpt_chars` characters. Extra
-/// trailing columns (e.g. `validity` used for ordering) are ignored.
+/// Parses a Cozo result row of `[id, type, name, body, …, validity]` into a
+/// `NodeBrief`, truncating `body` to `excerpt_chars` characters. The node's
+/// `ts` is read from the row's **last** column when it carries a `validity`
+/// (every brief query binds it there for ordering); rows without one yield
+/// `ts: None`. Any other trailing columns are ignored.
 pub(crate) fn parse_brief(row: &[DataValue], excerpt_chars: usize) -> NodeBrief {
     let id = row
         .first()
@@ -92,11 +99,17 @@ pub(crate) fn parse_brief(row: &[DataValue], excerpt_chars: usize) -> NodeBrief 
         .get(3)
         .and_then(|v| v.get_str())
         .map(|s| truncate_excerpt(s, excerpt_chars));
+    // Brief queries bind `validity` as the last column (for `:order`); the
+    // body lives at index 3, so a 4-column row has no validity and yields
+    // `None` here. Reading `last()` keeps this agnostic to the column count
+    // (fts adds a `score` column before validity, others don't).
+    let ts = validity_seconds(row.last());
     NodeBrief {
         id,
         node_type,
         name,
         body_excerpt,
+        ts,
     }
 }
 

--- a/kaeru-core/src/recall/recollect.rs
+++ b/kaeru-core/src/recall/recollect.rs
@@ -97,10 +97,10 @@ fn recollect_briefs_by_archival_type(store: &Store, node_type: &str) -> Result<V
     let mut params: BTreeMap<String, DataValue> = BTreeMap::new();
     params.insert("nt".to_string(), DataValue::Str(node_type.into()));
 
-    // `validity` is bound for ordering only; `parse_brief` reads columns
-    // 0..=3 and ignores the trailing validity column. When an initiative
-    // is active, the read joins `node_initiative` so only nodes
-    // attached to that initiative surface.
+    // `validity` is bound last for `:order` and is also read by
+    // `parse_brief` (from the trailing column) into the brief's `ts`. When
+    // an initiative is active, the read joins `node_initiative` so only
+    // nodes attached to that initiative surface.
     let script = match store.current_initiative() {
         Some(init) => {
             params.insert("init".to_string(), DataValue::Str(init.into()));

--- a/kaeru-core/src/recall/summary_view.rs
+++ b/kaeru-core/src/recall/summary_view.rs
@@ -44,7 +44,7 @@ pub fn summary_view(store: &Store, seed: &NodeId) -> Result<SummaryView> {
         Some(init) => {
             p_root.insert("init".to_string(), DataValue::Str(init.clone().into()));
             r#"
-                ?[id, type, name, body] := *node{id, type, name, body @ 'NOW'},
+                ?[id, type, name, body, validity] := *node{id, type, name, body, validity @ 'NOW'},
                                             id = $seed,
                                             *node_initiative{initiative, node_id: id},
                                             initiative = $init
@@ -52,7 +52,7 @@ pub fn summary_view(store: &Store, seed: &NodeId) -> Result<SummaryView> {
         }
         None => {
             r#"
-                ?[id, type, name, body] := *node{id, type, name, body @ 'NOW'}, id = $seed
+                ?[id, type, name, body, validity] := *node{id, type, name, body, validity @ 'NOW'}, id = $seed
             "#
         }
     };
@@ -83,8 +83,8 @@ pub fn summary_view(store: &Store, seed: &NodeId) -> Result<SummaryView> {
                 candidates[child] := *edge{src: child, dst, edge_type @ 'NOW'},
                                      dst = $seed,
                                      edge_type = 'part_of'
-                ?[id, type, name, body] := candidates[id],
-                                            *node{id, type, name, body @ 'NOW'},
+                ?[id, type, name, body, validity] := candidates[id],
+                                            *node{id, type, name, body, validity @ 'NOW'},
                                             *node_initiative{initiative, node_id: id},
                                             initiative = $init
             "#
@@ -97,7 +97,7 @@ pub fn summary_view(store: &Store, seed: &NodeId) -> Result<SummaryView> {
                 candidates[child] := *edge{src: child, dst, edge_type @ 'NOW'},
                                      dst = $seed,
                                      edge_type = 'part_of'
-                ?[id, type, name, body] := candidates[id], *node{id, type, name, body @ 'NOW'}
+                ?[id, type, name, body, validity] := candidates[id], *node{id, type, name, body, validity @ 'NOW'}
             "#
         }
     };

--- a/kaeru-mcp/src/server.rs
+++ b/kaeru-mcp/src/server.rs
@@ -698,6 +698,8 @@ impl ServerHandler for KaeruServer {
               `topic:<word>` tokens from body. Slice by tag via `tagged \"topic:...\"` etc. \
               \
               FRESHNESS: search/recall results sort newest-first within equal scores; recent captures beat stale ones. \
+              Every brief and snapshot shows its assertion time (absolute + relative, e.g. `2026-06-23 11:21 · 2d ago`); \
+              `read_chain` stamps each step, so you can follow the chronology of work and thought without calling `history`. \
               \
               Inquire with `drill <name>`, `trace <name>`, `search <query>`, `tagged <tag>`. Bi-temporal handle: \
               `at`, `history`."

--- a/kaeru-mcp/src/tools/chain.rs
+++ b/kaeru-mcp/src/tools/chain.rs
@@ -7,7 +7,7 @@ use kaeru_core::Store;
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
 
-use crate::utils::{resolve_name_or_id, text, to_mcp, with_initiative};
+use crate::utils::{resolve_name_or_id, text, to_mcp, ts_suffix, with_initiative};
 
 /// Materializes the shortest weighted path `from → to` as a saved chain.
 pub fn chain(
@@ -78,11 +78,12 @@ pub fn read_chain(
         let mut out = format!("chain `{name_or_id}` ({} nodes):\n", members.len());
         for (i, m) in members.iter().enumerate() {
             out.push_str(&format!(
-                "{}. {} ({}) — {}\n",
+                "{}. {} ({}) — {}{}\n",
                 i + 1,
                 m.name,
                 m.node_type,
-                m.id
+                m.id,
+                ts_suffix(m.ts)
             ));
             if let Some(e) = &m.body_excerpt {
                 out.push_str(&format!("   {e}\n"));

--- a/kaeru-mcp/src/tools/temporal.rs
+++ b/kaeru-mcp/src/tools/temporal.rs
@@ -6,7 +6,7 @@ use kaeru_core::{NodeSnapshot, Store};
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
 
-use crate::utils::{parse_when, resolve_name, text, to_mcp, with_initiative};
+use crate::utils::{fmt_ts, parse_when, resolve_name, text, to_mcp, with_initiative};
 
 /// Reads a node **in full** — every field plus the complete, untruncated
 /// body. `when` is optional: omit it to read the node as it is now, or pass
@@ -67,6 +67,9 @@ fn render(s: &NodeSnapshot, when: Option<&str>) -> String {
         "layer: {}   visibility: {}\n",
         s.layer, s.visibility
     ));
+    if let Some(ts) = s.ts {
+        out.push_str(&format!("recorded: {}\n", fmt_ts(ts)));
+    }
     if !s.tags.is_empty() {
         out.push_str(&format!("tags: {}\n", s.tags.join(", ")));
     }

--- a/kaeru-mcp/src/utils.rs
+++ b/kaeru-mcp/src/utils.rs
@@ -11,6 +11,7 @@
 //! Call sites live in `tools/<group>.rs`.
 
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, NaiveDate, Utc};
 use kaeru_core::{Error, Layer, NodeBrief, NodeId, Store, SummaryView, Tier};
@@ -40,10 +41,52 @@ pub fn brief_suffix(store: &Store, id: &str) -> String {
     }
 }
 
+/// Formats a Unix-seconds timestamp as `2026-06-23 11:21 · 2d ago` — an
+/// absolute UTC stamp for unambiguous ordering plus a relative "ago" for
+/// quick freshness. Gives every brief / snapshot a chronological anchor so
+/// the agent can follow the order of work and thought.
+pub fn fmt_ts(secs: f64) -> String {
+    let abs = DateTime::<Utc>::from_timestamp(secs as i64, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "?".to_string());
+    format!("{abs} · {}", humanize_ago(secs))
+}
+
+/// How long ago `secs` (Unix seconds) was, relative to now: `just now`,
+/// `5m ago`, `3h ago`, `2d ago`, `4w ago`. Future stamps (clock skew) read
+/// as `just now`.
+fn humanize_ago(secs: f64) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(secs);
+    let delta = now - secs;
+    if delta < 60.0 {
+        "just now".to_string()
+    } else if delta < 3_600.0 {
+        format!("{}m ago", (delta / 60.0) as i64)
+    } else if delta < 86_400.0 {
+        format!("{}h ago", (delta / 3_600.0) as i64)
+    } else if delta < 604_800.0 {
+        format!("{}d ago", (delta / 86_400.0) as i64)
+    } else {
+        format!("{}w ago", (delta / 604_800.0) as i64)
+    }
+}
+
+/// ` · <abs · rel>` suffix for a brief's timestamp, or `""` when the node
+/// carried no parseable validity.
+pub fn ts_suffix(ts: Option<f64>) -> String {
+    ts.map(|s| format!(" · {}", fmt_ts(s))).unwrap_or_default()
+}
+
 pub fn render_summary(view: &SummaryView) -> String {
     let mut out = format!(
-        "{} ({}) — {}\n",
-        view.root.name, view.root.node_type, view.root.id
+        "{} ({}) — {}{}\n",
+        view.root.name,
+        view.root.node_type,
+        view.root.id,
+        ts_suffix(view.root.ts)
     );
     if let Some(e) = &view.root.body_excerpt {
         out.push_str(&format!("  {e}\n"));
@@ -53,7 +96,13 @@ pub fn render_summary(view: &SummaryView) -> String {
     } else {
         out.push_str(&format!("children ({}):\n", view.children.len()));
         for c in &view.children {
-            out.push_str(&format!("  - {} ({}) — {}\n", c.name, c.node_type, c.id));
+            out.push_str(&format!(
+                "  - {} ({}) — {}{}\n",
+                c.name,
+                c.node_type,
+                c.id,
+                ts_suffix(c.ts)
+            ));
             if let Some(e) = &c.body_excerpt {
                 out.push_str(&format!("    {e}\n"));
             }
@@ -68,7 +117,13 @@ pub fn render_briefs(label: &str, briefs: &[NodeBrief]) -> String {
     }
     let mut out = format!("{label} ({}):\n", briefs.len());
     for b in briefs {
-        out.push_str(&format!("  - {} ({}) — {}\n", b.name, b.node_type, b.id));
+        out.push_str(&format!(
+            "  - {} ({}) — {}{}\n",
+            b.name,
+            b.node_type,
+            b.id,
+            ts_suffix(b.ts)
+        ));
         if let Some(e) = &b.body_excerpt {
             out.push_str(&format!("    {e}\n"));
         }


### PR DESCRIPTION
## Why

An agent reading its memory back can't tell *when* anything was captured. To follow the order of work and thought it has to call `history` node by node — there's no chronology in the everyday reads (`search` / `drill` / `recall` / `read_chain`).

The data is already there: the bi-temporal substrate stamps every node with a `validity`, and nearly every read query already **selects** it — purely to `:order` by it, then throws it away in `parse_brief`. So this is not a new field; it's surfacing one that's already fetched and discarded.

## What changes

**Core (`kaeru-core`) — no schema change**
- `NodeBrief` gains `ts: Option<f64>`. `parse_brief` reads it from the row's **last** column (every brief query binds `validity` there for ordering; the `fts` `score` column sits before it, so reading `last()` stays agnostic to column count).
- The three brief queries that didn't select `validity` now do: `node_brief_by_id`, `nodes_in_initiative`, `summary_view`. That covers `search`, `drill`, `recall`, `tagged`, `recollect`, `layer`, `read_chain`, and `chains` (the last two flow through `node_brief_by_id`).
- `NodeSnapshot` (the `at` full read) gains `ts`, bound from the as-of validity.
- New `validity_seconds(dv)` helper: a validity column → Unix seconds for an asserted row, `None` otherwise. Safe to call on any trailing column.

**Rendering (`kaeru-mcp`)**
- `fmt_ts` renders **absolute + relative**: `2026-06-23 11:21 · 2d ago`.
- Brief lists and the `drill` summary append it per node; `read_chain` stamps each step so the trail reads as a timeline; `at` adds a `recorded:` line.
- Server instructions note the new chronology in the `FRESHNESS` block.

## Verification

- `cargo check --workspace` / `cargo test --workspace` — clean (kaeru-core 73 tests)
- New test: `at` and a `NodeBrief` expose the **same** assertion time, in Unix seconds (not Cozo's microsecond `@ 'NOW'` scale).

## Example

```
search "chain rule" (2):
  - развилка-куда-зашить-правило-цепочек (episode) — 019efe74-… · 2026-06-25 14:02 · 3h ago
  - global-rule-всегда-строить-цепочки (reference) — 019efe6d-… · 2026-06-24 09:13 · 1d ago
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)