### PR TITLE
fix(mcp): set request/connect timeouts on the cloud HTTP client

### DIFF
--- a/kaeru-mcp/src/cloud_client.rs
+++ b/kaeru-mcp/src/cloud_client.rs
@@ -8,8 +8,18 @@
 //! empty *expected* token as auth-disabled).
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use serde_json::Value;
+
+/// Hard ceiling on any single cloud request. Without it a dead or
+/// black-holed connection blocks the calling MCP tool indefinitely —
+/// reqwest sets no total-request timeout by default.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Ceiling on TCP connect alone, so an unreachable host fails fast
+/// instead of waiting out the OS connect timeout.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Holds the cloud base URL, the bearer token, and a reusable reqwest
 /// client (cheap to clone — it shares a connection pool internally).
@@ -22,10 +32,18 @@ pub struct CloudClient {
 
 impl CloudClient {
     pub fn new(base_url: String, token: String) -> Self {
+        // `Client::builder()` only fails when TLS/system config is broken;
+        // fall back to the default client rather than panicking the daemon —
+        // a cloud client without timeouts still beats no daemon at all.
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         Self {
             base_url: base_url.trim_end_matches('/').to_string(),
             token,
-            client: reqwest::Client::new(),
+            client,
         }
     }
 


### PR DESCRIPTION
## Problem

`CloudClient` builds its HTTP client as `reqwest::Client::new()`, which ships with **no total-request timeout**. A dead or black-holed `kaeru-cloud` connection therefore blocks the calling MCP tool (`share` / `pull` / `cloud_recall` / `sync_review`) indefinitely — the agent's session just hangs until the OS gives up, if it ever does.

## Change

Build the client with a 30 s request ceiling and a 10 s connect ceiling. If the builder itself fails (broken TLS/system config — the only way it can), fall back to the default client rather than panicking the daemon: a cloud client without timeouts still beats no daemon at all.

No behaviour change on the happy path; retries are deliberately **not** included (that's policy and deserves its own discussion).

## Testing

- `cargo test --workspace` green (kaeru-mcp 9/9 incl. the `cloud_client` unit tests).
- `cargo clippy` — no new warnings vs `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
