### PR TITLE
feat(cloud): GET /api/v1/initiatives — list initiatives with live node counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,11 +1780,13 @@ version = "0.4.0"
 dependencies = [
  "axum",
  "config",
+ "http-body-util",
  "kaeru-core",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]

--- a/kaeru-cloud/Cargo.toml
+++ b/kaeru-cloud/Cargo.toml
@@ -20,3 +20,9 @@ serde.workspace = true
 serde_json.workspace = true
 config.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+# Router-level tests: `tower::util::ServiceExt::oneshot` drives the axum
+# app without binding a socket; `http-body-util` collects response bodies.
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/kaeru-cloud/src/api/router/initiatives.rs
+++ b/kaeru-cloud/src/api/router/initiatives.rs
@@ -1,9 +1,11 @@
 //! Initiative endpoints — discovery for cross-session / cross-user recall.
 //!
-//! `GET /api/v1/initiatives/{name}/nodes` lists the shared nodes the cloud
-//! holds for an initiative, as compact briefs. The local daemon calls this
-//! so an agent can see what team knowledge exists, then `pull` individual
-//! nodes by id.
+//! `GET /api/v1/initiatives` lists every initiative the cloud holds, with a
+//! live node count — the entry point when a client knows the cloud exists
+//! but not what's in it. `GET /api/v1/initiatives/{name}/nodes` lists the
+//! shared nodes the cloud holds for one initiative, as compact briefs. The
+//! local daemon calls these so an agent can see what team knowledge exists,
+//! then `pull` individual nodes by id.
 
 use std::sync::Arc;
 
@@ -11,7 +13,8 @@ use axum::extract::{Path, State};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use kaeru_core::{
-    Error, Store, delete_initiative, edges_in_initiative, nodes_in_initiative, rename_initiative,
+    Error, Store, count_nodes_in_initiative, delete_initiative, edges_in_initiative,
+    list_initiatives, nodes_in_initiative, rename_initiative,
 };
 use serde::{Deserialize, Serialize};
 
@@ -22,10 +25,36 @@ use crate::errors::ApiError;
 
 pub fn initiatives_router() -> Router<AppState> {
     Router::new()
+        .route("/", get(list_all))
         .route("/{name}/nodes", get(list_nodes))
         .route("/{name}/edges", get(list_edges))
         .route("/{name}/rename", post(rename))
         .route("/{name}", delete(remove))
+}
+
+/// One row of the initiative listing: the name plus a live (at NOW,
+/// audit-events excluded) node count.
+#[derive(Debug, Serialize)]
+pub struct InitiativeBrief {
+    pub name: String,
+    pub nodes: usize,
+}
+
+/// Lists every initiative the cloud holds, with live node counts. Names
+/// come from the append-only `node_initiative` junction, so an initiative
+/// whose nodes were all since forgotten still appears — with `nodes: 0` —
+/// which is itself useful discovery signal.
+async fn list_all(
+    _: Authenticated,
+    State(store): State<Arc<Store>>,
+) -> Result<Json<Vec<InitiativeBrief>>, ApiError> {
+    let names = list_initiatives(&store)?;
+    let mut views = Vec::with_capacity(names.len());
+    for name in names {
+        let nodes = count_nodes_in_initiative(&store, &name)?;
+        views.push(InitiativeBrief { name, nodes });
+    }
+    Ok(Json(views))
 }
 
 #[derive(Debug, Deserialize)]
@@ -118,4 +147,82 @@ async fn list_edges(
         })
         .collect();
     Ok(Json(views))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use kaeru_core::Store;
+    use tower::util::ServiceExt;
+
+    use crate::api::router::api_router;
+    use crate::api::state::AppState;
+
+    /// Full app router over an in-memory store holding one node in each of
+    /// two initiatives, with auth disabled (empty expected token).
+    fn app() -> axum::Router {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("alpha");
+        kaeru_core::jot(&store, "seed for alpha").expect("jot alpha");
+        store.use_initiative("beta");
+        kaeru_core::jot(&store, "seed for beta").expect("jot beta");
+        api_router(AppState {
+            api_token: Arc::from(""),
+            store: Arc::new(store),
+        })
+    }
+
+    #[tokio::test]
+    async fn lists_initiatives_with_live_counts() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/initiatives")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let views: Vec<serde_json::Value> = serde_json::from_slice(&bytes).unwrap();
+        let pairs: Vec<(String, u64)> = views
+            .iter()
+            .map(|v| {
+                (
+                    v["name"].as_str().unwrap().to_string(),
+                    v["nodes"].as_u64().unwrap(),
+                )
+            })
+            .collect();
+        // Audit-event nodes are excluded from counts; names sort alphabetically.
+        assert_eq!(
+            pairs,
+            vec![("alpha".to_string(), 1), ("beta".to_string(), 1)]
+        );
+    }
+
+    #[tokio::test]
+    async fn listing_requires_auth_when_token_configured() {
+        let store = Store::open_in_memory().expect("open");
+        let app = api_router(AppState {
+            api_token: Arc::from("sekret"),
+            store: Arc::new(store),
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/initiatives")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
 }


### PR DESCRIPTION
## Problem

The cloud has per-initiative discovery (`/{name}/nodes`, `/{name}/edges`) but no way to learn **which initiatives exist** in the first place. A client that knows the cloud URL but not the exact initiative name is blind — and because a name miss reads as an empty initiative (`200 []`), a typo is indistinguishable from "the cloud is empty" (see the incident described in #28). We hit exactly this in production: a teammate couldn't tell whether the cloud held anything at all, and diagnosing it required raw `curl` guesswork.

## Change

`GET /api/v1/initiatives` → `[{ "name": "...", "nodes": N }, …]`, behind the same `Authenticated` extractor as the rest of the API. Both primitives already existed in kaeru-core (`list_initiatives`, `count_nodes_in_initiative`) — this just wires them to a route. Names come from the append-only junction, so an initiative whose nodes were all since forgotten still appears with `nodes: 0`, which is itself useful discovery signal (documented on the handler).

## Testing

Adds the crate's first router-level tests (`tower::util::ServiceExt::oneshot` over an in-memory store, no socket):

- listing returns both seeded initiatives with live counts, audit events excluded;
- 401 when a bearer token is configured and the request carries none.

`cargo test --workspace` green; `cargo clippy` — no new warnings vs `main`. New dev-deps for the tests only: `tower` (util), `http-body-util`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
