### PR TITLE
feat(core): lint detects dangling edges — closes the in-code known follow-up

### DIFF
--- a/kaeru-core/src/recall/lint.rs
+++ b/kaeru-core/src/recall/lint.rs
@@ -1,5 +1,5 @@
-//! `lint` — read-only graph-hygiene snapshot. Surfaces orphan nodes and
-//! the unresolved-review queue in one report.
+//! `lint` — read-only graph-hygiene snapshot. Surfaces orphan nodes,
+//! the unresolved-review queue, and dangling edges in one report.
 
 use std::collections::BTreeMap;
 
@@ -22,16 +22,19 @@ pub struct LintReport {
     /// the open-review queue. Mirror of `under_review_pinned` surfaced
     /// here so a single `lint` call returns the agent's hygiene to-do list.
     pub unresolved_reviews: Vec<NodeId>,
+    /// Edges valid at NOW where at least one endpoint is no longer a
+    /// live node — `(src, dst, edge_type)`. These arise when a node is
+    /// retracted without its edges (e.g. `consolidate` retracts the
+    /// draft but leaves its old edges asserted). Not corruption — the
+    /// bi-temporal substrate keeps the history intact — but a traversal
+    /// at NOW walks into nothing, so they usually want re-pointing at
+    /// the successor node or retracting.
+    pub dangling_edges: Vec<(NodeId, NodeId, String)>,
 }
 
 /// Returns a diagnostic snapshot of graph hygiene at NOW. Read-only.
 ///
-/// MVP scope covers orphans and unresolved reviews. Dangling edges
-/// (edges valid at NOW pointing at retracted endpoints) are a known
-/// follow-up — they require parsing each edge's endpoints against the
-/// current node set, and the bi-temporal substrate already keeps the
-/// historical edge intact, so the issue surfaces as a query-time
-/// anomaly rather than corruption.
+/// Covers orphans, unresolved reviews, and dangling edges.
 pub fn lint(store: &Store) -> Result<LintReport> {
     // Orphans: nodes valid at NOW that don't appear as `src` or `dst` of
     // any edge valid at NOW. When an initiative is active, the projection
@@ -69,8 +72,102 @@ pub fn lint(store: &Store) -> Result<LintReport> {
 
     let unresolved_reviews = under_review_pinned(store)?;
 
+    // Dangling edges: edges valid at NOW whose src and/or dst is not a
+    // live node at NOW. When an initiative is active, an edge is in scope
+    // if either endpoint is attached to it — the junction is append-only,
+    // so a retracted endpoint still carries its membership row.
+    let mut params: BTreeMap<String, DataValue> = BTreeMap::new();
+    let dangling_script = match store.current_initiative() {
+        Some(init) => {
+            params.insert("init".to_string(), DataValue::Str(init.into()));
+            r#"
+                alive[id] := *node{id, type @ 'NOW'}
+                member[id] := *node_initiative{initiative, node_id: id}, initiative = $init
+                scoped[src, dst, edge_type] := *edge{src, dst, edge_type @ 'NOW'}, member[src]
+                scoped[src, dst, edge_type] := *edge{src, dst, edge_type @ 'NOW'}, member[dst]
+                ?[src, dst, edge_type] := scoped[src, dst, edge_type], not alive[src]
+                ?[src, dst, edge_type] := scoped[src, dst, edge_type], not alive[dst]
+            "#
+        }
+        None => {
+            r#"
+                alive[id] := *node{id, type @ 'NOW'}
+                ?[src, dst, edge_type] := *edge{src, dst, edge_type @ 'NOW'}, not alive[src]
+                ?[src, dst, edge_type] := *edge{src, dst, edge_type @ 'NOW'}, not alive[dst]
+            "#
+        }
+    };
+    let rows = store
+        .db_ref()
+        .run_script(dangling_script, params, ScriptMutability::Immutable)?;
+    let dangling_edges: Vec<(NodeId, NodeId, String)> = rows
+        .rows
+        .iter()
+        .filter_map(|r| {
+            let src = r.first().and_then(|v| v.get_str())?;
+            let dst = r.get(1).and_then(|v| v.get_str())?;
+            let edge_type = r.get(2).and_then(|v| v.get_str())?;
+            Some((src.to_string(), dst.to_string(), edge_type.to_string()))
+        })
+        .collect();
+
     Ok(LintReport {
         orphans,
         unresolved_reviews,
+        dangling_edges,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::graph::{EdgeType, NodeType};
+    use crate::store::Store;
+
+    /// `consolidate_out` retracts the draft node but leaves its old edges
+    /// asserted — the canonical dangling-edge factory. `lint` must report
+    /// them; the live replacement edge set must stay clean.
+    #[test]
+    fn lint_reports_edges_left_behind_by_consolidation() {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("demo");
+
+        let a = crate::jot(&store, "draft under test").expect("jot a");
+        let b = crate::jot(&store, "stable neighbour").expect("jot b");
+        crate::link(&store, &a, &b, EdgeType::RefersTo).expect("link a->b");
+
+        let before = crate::lint(&store).expect("lint before");
+        assert!(
+            before.dangling_edges.is_empty(),
+            "no dangling edges while both endpoints are alive"
+        );
+
+        // Validity has whole-second resolution; a retraction in the same
+        // second as the assertion is ambiguous at `@ 'NOW'`. Sleep across
+        // the second boundary, as the rest of the test suite does.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let new_id = crate::consolidate_out(&store, &a, NodeType::Outcome, "a-settled", "body")
+            .expect("consolidate");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        let after = crate::lint(&store).expect("lint after");
+        let refers = (a.clone(), b.clone(), "refers_to".to_string());
+        let consolidated = (a.clone(), new_id.clone(), "consolidated_to".to_string());
+        assert!(
+            after.dangling_edges.contains(&refers),
+            "old refers_to edge from the retracted draft is dangling: {:?}",
+            after.dangling_edges
+        );
+        assert!(
+            after.dangling_edges.contains(&consolidated),
+            "consolidated_to edge hangs off the retracted draft: {:?}",
+            after.dangling_edges
+        );
+        assert!(
+            !after
+                .dangling_edges
+                .iter()
+                .any(|(s, d, _)| s == &new_id && d == &b),
+            "edges of the live replacement are not dangling"
+        );
+    }
 }

--- a/kaeru-mcp/src/tools/lint.rs
+++ b/kaeru-mcp/src/tools/lint.rs
@@ -33,6 +33,14 @@ pub fn lint(store: &Store, initiative: Option<&str>) -> Result<CallToolResult, M
         for id in &report.unresolved_reviews {
             out.push_str(&format!("  - {id}{}\n", brief_suffix(store, id)));
         }
+        out.push('\n');
+        out.push_str(&format!(
+            "dangling edges ({}) — an endpoint was retracted; re-point at its successor or unlink:\n",
+            report.dangling_edges.len()
+        ));
+        for (src, dst, edge_type) in &report.dangling_edges {
+            out.push_str(&format!("  - {src} -[{edge_type}]-> {dst}\n"));
+        }
         Ok(text(&out))
     })
 }

--- a/kaeru-rig/src/manage.rs
+++ b/kaeru-rig/src/manage.rs
@@ -210,14 +210,15 @@ mem_tool!(
     /// `kaeru_lint` — surface orphans and unresolved reviews.
     Lint,
     "kaeru_lint",
-    "Check the memory for hygiene issues: orphan nodes (no edges) and unresolved review flags. \
-     Use it to find loose ends worth tidying.",
+    "Check the memory for hygiene issues: orphan nodes (no edges), unresolved review flags, and \
+     dangling edges (an endpoint was retracted). Use it to find loose ends worth tidying.",
     NoArgs,
     { "type": "object", "properties": {} },
     |store, _args| match lint(store) {
         Ok(report) => json!({
             "orphans": report.orphans,
             "unresolved_reviews": report.unresolved_reviews,
+            "dangling_edges": report.dangling_edges,
         }),
         Err(e) => json!({ "error": e.to_string() }),
     }


### PR DESCRIPTION
## Problem

Edges valid at NOW whose endpoint has been retracted walk a traversal into nothing. They arise routinely — `consolidate` retracts the draft node but leaves its old edges asserted — and today nothing surfaces them. The `lint` doc comment already names dangling edges as a known follow-up; this implements it.

## Change

- `LintReport` grows `dangling_edges: Vec<(src, dst, edge_type)>` — edges valid at NOW where at least one endpoint is not a live node. Initiative-scoped via **either** endpoint's junction membership (the junction is append-only, so a retracted endpoint keeps its row — which is exactly what makes the scoped query possible).
- The MCP `lint` tool renders a section with a re-point-or-unlink hint; `kaeru_lint` in kaeru-rig passes the field through.
- Doc comment updated (no longer a follow-up).

## Testing

Regression test builds the canonical case: `a —refers_to→ b`, then `consolidate_out(a)` — lint must report both the stale `refers_to` and the `consolidated_to` hanging off the retracted draft, and must **not** flag the live replacement's edges. The test sleeps across second boundaries like the rest of the suite (whole-second Validity).

`cargo test --workspace` green (kaeru-core 85/85 on this branch); `cargo clippy` — no new warnings vs `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
