### PR TITLE
fix(core): consolidate/synthesise/chain inherit source initiatives when unscoped

### DIFF
--- a/kaeru-core/src/mutate/chain.rs
+++ b/kaeru-core/src/mutate/chain.rs
@@ -198,6 +198,17 @@ pub fn create_chain(
         Visibility::Local,
         Layer::Warm,
     )?;
+    // With no active scope the upsert left the chain node without any
+    // membership — but its members all belong somewhere, and a chain
+    // invisible to every scoped read is never intended. Inherit the union
+    // of the members' initiatives (idempotent junction writes).
+    if initiative.is_none() {
+        for member in &path {
+            for init in super::initiatives_of_node(store, member)? {
+                super::attach_node_to_initiative_named(store, &chain_id, &init)?;
+            }
+        }
+    }
     replace_members(store, &chain_id, &path)?;
 
     write_audit(
@@ -306,6 +317,24 @@ mod tests {
         link_with_weight(store, &a, &b, EdgeType::RefersTo, 0.9).unwrap();
         link_with_weight(store, &b, &c, EdgeType::RefersTo, 0.9).unwrap();
         (a, b, c)
+    }
+
+    /// A chain materialised with no active scope inherits the union of its
+    /// members' initiatives instead of landing membership-less (issue #25
+    /// family — same guarantee as consolidate/synthesise).
+    #[test]
+    fn create_chain_without_scope_inherits_member_initiatives() {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("p");
+        let (a, _b, c) = line_abc(&store);
+
+        store.clear_initiative();
+        let outcome = create_chain(&store, &a, &c, None, None)
+            .expect("create")
+            .expect("path exists");
+
+        let inits = crate::mutate::initiatives_of_node(&store, &outcome.id).expect("junction read");
+        assert_eq!(inits, vec!["p".to_string()]);
     }
 
     #[test]

--- a/kaeru-core/src/mutate/consolidate.rs
+++ b/kaeru-core/src/mutate/consolidate.rs
@@ -8,8 +8,9 @@ use std::collections::BTreeMap;
 use cozo::{DataValue, ScriptMutability};
 
 use super::{
-    attach_edge_to_initiative, attach_node_to_initiative, build_body_tags, now_validity_seconds,
-    read_derived_from_targets, tags_literal,
+    attach_edge_to_initiative, attach_node_to_initiative, attach_node_to_initiative_named,
+    build_body_tags, initiatives_of_node, now_validity_seconds, read_derived_from_targets,
+    tags_literal,
 };
 use crate::errors::Result;
 use crate::graph::audit::write_audit;
@@ -131,6 +132,16 @@ fn consolidate(
         .db_ref()
         .run_script(&s2, p2, ScriptMutability::Mutable)?;
     attach_node_to_initiative(store, &new_id)?;
+    // With no active scope the junction write above was a no-op — but the
+    // old node belonged somewhere, and it was just retracted. Losing its
+    // replacement from those initiatives is never intended (the node
+    // becomes invisible to every scoped read), so inherit the source's
+    // memberships instead.
+    if store.current_initiative().is_none() {
+        for init in initiatives_of_node(store, old_id)? {
+            attach_node_to_initiative_named(store, &new_id, &init)?;
+        }
+    }
 
     // Step 3 — replicate derived_from edges so provenance survives the
     // tier boundary.
@@ -176,4 +187,68 @@ fn consolidate(
         &[old_id.clone(), new_id.clone()],
     )?;
     Ok(new_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::graph::{NodeType, Tier};
+    use crate::store::Store;
+
+    /// A consolidation performed with no active initiative scope used to
+    /// leave the replacement node without any membership — invisible to
+    /// every scoped read — while the source (which had memberships) got
+    /// retracted. The replacement must inherit the source's initiatives.
+    #[test]
+    fn consolidate_without_scope_inherits_source_initiatives() {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("demo");
+        let draft = crate::jot(&store, "scoped draft").expect("jot");
+
+        store.clear_initiative();
+        let settled =
+            crate::consolidate_out(&store, &draft, NodeType::Outcome, "settled-x", "body")
+                .expect("consolidate");
+
+        let inits = super::super::initiatives_of_node(&store, &settled).expect("junction read");
+        assert_eq!(inits, vec!["demo".to_string()]);
+    }
+
+    /// Same guarantee for `synthesise`: with no scope active the new node
+    /// inherits the union of the seeds' initiatives.
+    #[test]
+    fn synthesise_without_scope_inherits_union_of_seed_initiatives() {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("alpha");
+        let a = crate::jot(&store, "seed a").expect("jot a");
+        store.use_initiative("beta");
+        let b = crate::jot(&store, "seed b").expect("jot b");
+
+        store.clear_initiative();
+        let s = crate::synthesise(
+            &store,
+            &[a, b],
+            NodeType::Summary,
+            Tier::Archival,
+            "union-synth",
+            "body",
+        )
+        .expect("synthesise");
+
+        let inits = super::super::initiatives_of_node(&store, &s).expect("junction read");
+        assert_eq!(inits, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    /// Explicit scope still wins — consolidation under an active initiative
+    /// attaches there and only there (existing behaviour, pinned by a test).
+    #[test]
+    fn consolidate_with_scope_attaches_to_that_scope() {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("demo");
+        let draft = crate::jot(&store, "scoped draft").expect("jot");
+        let settled =
+            crate::consolidate_out(&store, &draft, NodeType::Outcome, "settled-y", "body")
+                .expect("consolidate");
+        let inits = super::super::initiatives_of_node(&store, &settled).expect("junction read");
+        assert_eq!(inits, vec!["demo".to_string()]);
+    }
 }

--- a/kaeru-core/src/mutate/mod.rs
+++ b/kaeru-core/src/mutate/mod.rs
@@ -260,6 +260,18 @@ pub(crate) fn attach_node_to_initiative(store: &Store, node_id: &NodeId) -> Resu
     let Some(initiative) = store.current_initiative() else {
         return Ok(());
     };
+    attach_node_to_initiative_named(store, node_id, &initiative)
+}
+
+/// Attaches `node_id` to an **explicitly named** initiative — the junction
+/// write behind [`attach_node_to_initiative`], usable when the membership
+/// comes from somewhere other than the store's current scope (e.g.
+/// consolidation inheriting the source node's initiatives). Idempotent.
+pub(crate) fn attach_node_to_initiative_named(
+    store: &Store,
+    node_id: &NodeId,
+    initiative: &str,
+) -> Result<()> {
     let mut params: BTreeMap<String, DataValue> = BTreeMap::new();
     params.insert("init".to_string(), DataValue::Str(initiative.into()));
     params.insert("nid".to_string(), DataValue::Str(node_id.clone().into()));
@@ -271,6 +283,28 @@ pub(crate) fn attach_node_to_initiative(store: &Store, node_id: &NodeId) -> Resu
         .db_ref()
         .run_script(script, params, ScriptMutability::Mutable)?;
     Ok(())
+}
+
+/// Returns every initiative `node_id` is attached to through the
+/// `node_initiative` junction. The junction is append-only, so this also
+/// answers for retracted nodes — which is exactly what consolidation needs
+/// when it inherits memberships from a node it just retracted.
+pub(crate) fn initiatives_of_node(store: &Store, node_id: &NodeId) -> Result<Vec<String>> {
+    let mut params: BTreeMap<String, DataValue> = BTreeMap::new();
+    params.insert("nid".to_string(), DataValue::Str(node_id.clone().into()));
+    let script = r#"
+        ?[initiative] := *node_initiative{initiative, node_id}, node_id = $nid
+        :order initiative
+    "#;
+    let rows = store
+        .db_ref()
+        .run_script(script, params, ScriptMutability::Immutable)?;
+    let names = rows
+        .rows
+        .iter()
+        .filter_map(|r| r.first().and_then(|v| v.get_str()).map(String::from))
+        .collect();
+    Ok(names)
 }
 
 /// Attaches an edge to the store's current initiative through the

--- a/kaeru-core/src/mutate/synthesise.rs
+++ b/kaeru-core/src/mutate/synthesise.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 use cozo::{DataValue, ScriptMutability};
 
 use super::{
-    attach_edge_to_initiative, attach_node_to_initiative, build_body_tags, now_validity_seconds,
-    tags_literal,
+    attach_edge_to_initiative, attach_node_to_initiative, attach_node_to_initiative_named,
+    build_body_tags, initiatives_of_node, now_validity_seconds, tags_literal,
 };
 use crate::errors::{Error, Result};
 use crate::graph::audit::write_audit;
@@ -66,6 +66,17 @@ pub fn synthesise(
         .run_script(&s1, p1, ScriptMutability::Mutable)?;
 
     attach_node_to_initiative(store, &new_id)?;
+    // With no active scope the junction write above was a no-op — but the
+    // seeds belong somewhere, and a synthesis invisible to every scoped
+    // read is never intended. Inherit the union of the seeds' memberships
+    // (the junction `:put` is idempotent, so overlaps are free).
+    if store.current_initiative().is_none() {
+        for seed in seeds {
+            for init in initiatives_of_node(store, seed)? {
+                attach_node_to_initiative_named(store, &new_id, &init)?;
+            }
+        }
+    }
 
     // Step 2 — derived_from edges from the new node to each seed. One
     // substrate write per seed to keep error attribution clean (a malformed


### PR DESCRIPTION
Closes #25.

## Problem

`attach_node_to_initiative` is a silent no-op without an active scope, so a `settle` / `synthesise` / `chain` call that omits the initiative leaves its result node **without any membership** — invisible to every scoped read (`recall`, `overview`, `awake`, `lint`) and only reachable cross-initiative. For consolidation this loses knowledge from the initiative outright: the source node (which had memberships) is retracted and its replacement lands nowhere. We hit this four independent times in real agent sessions (details and live repro in #25; the chain variant is in the issue comments).

## Change

When **no scope is active**:

- `consolidate()` inherits the retracted source's initiatives;
- `synthesise()` inherits the union of its seeds';
- `create_chain()` inherits the union of its members'.

An explicit scope keeps winning (unchanged behaviour, now pinned by a test). The junction `:put` is idempotent, so overlapping memberships are free; reading the just-retracted source's memberships is safe because the junction is append-only. Two small `pub(crate)` helpers added in `mutate/mod.rs`: `attach_node_to_initiative_named` (the junction write behind the scoped variant) and `initiatives_of_node`.

## Testing

Four regression tests:

- consolidate without scope inherits the source's initiative;
- synthesise without scope inherits the union of two seeds' initiatives;
- consolidate **with** scope attaches to that scope only;
- chain materialised without scope inherits its members' initiative.

`cargo test --workspace` green (kaeru-core 88/88 on this branch); `cargo clippy` — no new warnings vs `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
