### PR TITLE
fix(guard): env_secret matches markers as the key's final word, not substring

### DIFF
--- a/kaeru-core/src/guard.rs
+++ b/kaeru-core/src/guard.rs
@@ -66,7 +66,10 @@ const TOKEN_PREFIXES: &[(&str, usize, &str, &str)] = &[
 ];
 
 /// Env-var key fragments that, when assigned a non-trivial value, signal a
-/// secret (`API_KEY=…`, `DB_PASSWORD=…`).
+/// secret (`API_KEY=…`, `DB_PASSWORD=…`). A marker matches the assignment
+/// key only as its **final word** — the whole key or a `_`-separated suffix
+/// (see [`find_secret_assignment`]): compound identifiers are head-final,
+/// so `GITHUB_TOKEN` *is* a token while `TOKEN_COUNTER` is a counter.
 const SECRET_KEY_MARKERS: &[&str] = &[
     "SECRET",
     "TOKEN",
@@ -175,16 +178,33 @@ fn find_prefixed_token(content: &str, prefix: &str, min_suffix: usize) -> Option
     None
 }
 
-/// Scans line by line for `KEY = value` where the key name contains a
+/// Scans line by line for `KEY = value` where the key's **final word** is a
 /// secret marker and the value is non-trivial (≥ 8 chars after trimming
 /// quotes / whitespace).
+///
+/// The key is the last identifier-like token of the LHS (`cfg.api_token` →
+/// `api_token`, `export GITHUB_TOKEN` → `GITHUB_TOKEN`), and a marker
+/// matches only as the whole key or a `_`-separated suffix of it. Substring
+/// matching flagged ordinary engineering notes — `token_counter =
+/// TokenCounterService()`, `max tokens = 100000` — and every such false
+/// positive silently keeps a node out of the shared cloud, so the rule errs
+/// on the side of "the marker must name what the value *is*".
 fn find_secret_assignment(content: &str) -> Option<String> {
     for line in content.lines() {
         let Some((lhs, rhs)) = line.split_once('=') else {
             continue;
         };
-        let key = lhs.trim().to_uppercase();
-        if key.is_empty() || !SECRET_KEY_MARKERS.iter().any(|m| key.contains(m)) {
+        let key = lhs
+            .trim()
+            .rsplit(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .next()
+            .unwrap_or("")
+            .to_uppercase();
+        let is_marker = !key.is_empty()
+            && SECRET_KEY_MARKERS
+                .iter()
+                .any(|m| key == *m || key.ends_with(&format!("_{m}")));
+        if !is_marker {
             continue;
         }
         let value = rhs
@@ -277,5 +297,45 @@ mod tests {
         // Known remaining gap (separate follow-up): a bare, prefix-less token
         // with no `=` and no known prefix slips both scanners.
         assert!(scan_public("db_pass_x7Fq2mK9").is_empty());
+    }
+
+    /// `env_secret` matches the marker as the key's final word, not as a
+    /// substring — ordinary code and prose that merely *mention* tokens must
+    /// stay clean, because every false positive silently keeps a node out of
+    /// the shared cloud (observed live: 23 of 27 local nodes in one
+    /// initiative were blocked by `token_counter`-style identifiers).
+    #[test]
+    fn env_secret_matches_marker_as_final_word_only() {
+        // Marker as a modifier (head is COUNTER / SCANNER / LIMIT) — clean.
+        assert!(is_clean("token_counter = TokenCounterService()"));
+        assert!(is_clean("secret_scanner = SecretScannerImpl::new()"));
+        assert!(is_clean("TOKEN_LIMIT = 12800000"));
+        // Prose around `=` — the last word is TOKENS (plural ≠ marker).
+        assert!(is_clean("max tokens = 100000 for the model"));
+        // Non-ASCII keys never equal the ASCII markers.
+        assert!(is_clean("лимит токенайзера = 8192 согласно доке"));
+
+        // Real assignments still hit: whole key, `_`-suffix, and through a
+        // qualified path.
+        assert!(
+            scan("TOKEN=abcdefgh1234")
+                .iter()
+                .any(|h| h.rule == "env_secret")
+        );
+        assert!(
+            scan("GITHUB_TOKEN=ghx_notaprefix12345")
+                .iter()
+                .any(|h| h.rule == "env_secret")
+        );
+        assert!(
+            scan("cfg.api_token = \"abcdefgh1234\"")
+                .iter()
+                .any(|h| h.rule == "env_secret")
+        );
+        assert!(
+            scan("AWS_SECRET_ACCESS_KEY = wJalrXUtnFEMI")
+                .iter()
+                .any(|h| h.rule == "env_secret")
+        );
     }
 }

--- a/kaeru-mcp/src/tools/cloud.rs
+++ b/kaeru-mcp/src/tools/cloud.rs
@@ -28,6 +28,14 @@ fn not_configured() -> McpError {
     )
 }
 
+/// Renders a guard hit as `rule: "fragment"`. The fragment is
+/// `GuardHit.matched`, which the guard already truncates for safe display —
+/// showing it is what lets a human tell a real secret from a false positive
+/// without re-reading the whole body.
+fn format_hit(h: &kaeru_core::GuardHit) -> String {
+    format!("{}: {:?}", h.rule, h.matched)
+}
+
 /// Reads or sets an initiative's sticky cloud `share_policy` (Gate 1).
 /// Omit `policy` to read the current value.
 pub fn policy(
@@ -90,11 +98,11 @@ pub async fn push_to_cloud(
     let scan_target = format!("{}\n{}", full.name, full.body.clone().unwrap_or_default());
     let hits = kaeru_core::guard::scan_public(&scan_target);
     if !hits.is_empty() && !force {
-        let rules: Vec<&str> = hits.iter().map(|h| h.rule).collect();
+        let shown: Vec<String> = hits.iter().map(format_hit).collect();
         return Ok(format!(
             "not shared: pre-share guard flagged {} secret(s) [{}]. Remove them, or force=true to override.",
             hits.len(),
-            rules.join(",")
+            shown.join("; ")
         ));
     }
 
@@ -450,7 +458,7 @@ pub fn sync_review(store: &Store, initiative: &str) -> Result<CallToolResult, Mc
     }
 
     let mut propose: Vec<&kaeru_core::NodeFull> = Vec::new();
-    let mut keep: Vec<(&kaeru_core::NodeFull, Vec<&str>)> = Vec::new();
+    let mut keep: Vec<(&kaeru_core::NodeFull, Vec<String>)> = Vec::new();
     for n in &locals {
         let target = format!("{}\n{}", n.name, n.body.clone().unwrap_or_default());
         // Strict scanner — the share gate must be ≥ the export gate (see `share`).
@@ -458,7 +466,10 @@ pub fn sync_review(store: &Store, initiative: &str) -> Result<CallToolResult, Mc
         if hits.is_empty() {
             propose.push(n);
         } else {
-            keep.push((n, hits.iter().map(|h| h.rule).collect()));
+            // Rule id + the matched fragment (already truncated by the
+            // guard for safe display) — without the fragment a false
+            // positive can't be recognised without re-reading the body.
+            keep.push((n, hits.iter().map(format_hit).collect()));
         }
     }
 
@@ -477,13 +488,13 @@ pub fn sync_review(store: &Store, initiative: &str) -> Result<CallToolResult, Mc
         "\nKEEP LOCAL ({}) — secret guard flagged:\n",
         keep.len()
     ));
-    for (n, rules) in &keep {
+    for (n, hits) in &keep {
         out.push_str(&format!(
             "  - {} ({}) — {} [{}]\n",
             n.name,
             n.node_type,
             n.id,
-            rules.join(",")
+            hits.join("; ")
         ));
     }
     out.push_str(


### PR DESCRIPTION
Closes #38.

## Problem

`find_secret_assignment` uppercases the whole LHS of a `KEY=value` line and matches `SECRET_KEY_MARKERS` with `contains`, so ordinary engineering content trips the `env_secret` rule: `token_counter = TokenCounterService()` (TOKEN ⊂ TOKEN_COUNTER), and even prose — `max tokens = 100000 for the model`. Because `shared` visibility is gated on the guard, every false positive **silently keeps a node local**: on a live vault, `sync_review` on one initiative showed 27 candidates → 23 KEEP LOCAL, all `[env_secret]`, none containing an actual secret — the mirror-to-cloud policy had quietly stopped working for whole workstreams. And since both `sync_review` and the `share` refusal print only the bare rule id, the false positive can't even be recognised without re-reading the body (full repro and live measurements in #38).

## Change

- **Marker matching is now by the key's final word.** The key is the last identifier-like token of the LHS (`cfg.api_token` → `api_token`, `export GITHUB_TOKEN` → `GITHUB_TOKEN`), and a marker matches only as the whole key or a `_`-separated suffix. Rationale: compound identifiers are head-final — `GITHUB_TOKEN` *is* a token, `TOKEN_COUNTER` is a counter, so the marker must name what the value *is*. Real assignments (`TOKEN=…`, `DB_PASSWORD=…`, `AWS_SECRET_ACCESS_KEY=…`, qualified paths) still hit; `token_counter`, `secret_scanner`, `TOKEN_LIMIT`, English prose, and non-ASCII keys no longer do.
- **`sync_review` and the `share` refusal show `rule: "fragment"`** using `GuardHit.matched` — already truncated by the guard for safe display — so a human can tell a false positive from a real hit at a glance.

Deliberate trade-off, called out in #38: marker-as-modifier names with a generic head (`SECRET_KEY_BASE`) no longer match `SECRET`; an explicit `_KEY_BASE`-style marker can be added if that pattern matters. This felt strictly better than false positives that silently break mirroring.

The `TOKEN_PREFIXES`, PEM-block, and `scan_public` phrase rules are untouched — this only sharpens `env_secret`.

## Testing

New regression test `env_secret_matches_marker_as_final_word_only`: five innocuous inputs stay clean (identifier-with-modifier ×3, prose, Cyrillic), four real assignments still hit (bare `TOKEN=`, `_`-suffix, qualified path, `AWS_SECRET_ACCESS_KEY`). All pre-existing guard tests pass unchanged — including `API_KEY=todo` (trivial value) staying clean and `DB_PASSWORD=…` hitting.

`cargo test --workspace` green; `cargo clippy` — no new warnings vs `main`; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
