### PR TITLE
feat(viz): reader — read a reasoning trail, not just survey it

### DIFF
--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -16,7 +16,8 @@
       <div id="rcanvas"><div id="rworld"><svg id="rtrack"></svg></div></div>
       <div id="manuscript"></div>
       <header id="rbar">
-        <button id="rBack" class="btn">← galaxy</button>
+        <button id="rPrev" class="btn" hidden>← back</button>
+        <button id="rBack" class="btn">galaxy</button>
         <div class="rtitle"><span class="rkind">reasoning chain</span><b id="rname">—</b></div>
         <div class="themeseg" id="rView" role="group" aria-label="reader view">
           <button type="button" id="rTrail" class="on">map</button>

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -100,10 +100,14 @@
     <!-- right rail: find a node by name, or narrow the galaxy to one project -->
     <aside id="rail">
       <div id="find">
-        <input id="findInput" type="search" placeholder="find a node…" autocomplete="off" spellcheck="false" />
-        <div id="findHits" hidden></div>
+        <label class="sr-only" for="findInput">Find a node by name</label>
+        <input id="findInput" type="search" placeholder="find a node…" autocomplete="off" spellcheck="false"
+               role="combobox" aria-expanded="false" aria-controls="findHits"
+               aria-autocomplete="list" aria-haspopup="listbox" />
+        <div id="findHits" role="listbox" aria-label="Search results" hidden></div>
       </div>
-      <div id="projects"></div>
+      <p id="findStatus" class="sr-only" role="status" aria-live="polite"></p>
+      <div id="projects" role="group" aria-label="Projects"></div>
       <div id="legend"></div>
     </aside>
 

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -15,7 +15,15 @@
     <section id="reader" hidden>
       <div id="rcanvas"><div id="rworld"><svg id="rtrack"></svg></div></div>
       <div id="manuscript"></div>
-      <div id="rhint">X — how far the reasoning ran · Y — depth: grounds below, consequences above</div>
+      <header id="rbar">
+        <button id="rBack" class="btn">← galaxy</button>
+        <div class="rtitle"><span class="rkind">reasoning chain</span><b id="rname">—</b></div>
+        <div class="themeseg" id="rView" role="group" aria-label="reader view">
+          <button type="button" id="rTrail" class="on">map</button>
+          <button type="button" id="rMs">read</button>
+        </div>
+      </header>
+      <div id="rhint">click a step to read it</div>
     </section>
 
     <header id="hud">
@@ -54,24 +62,6 @@
           <select id="focus" class="ctl"><option value="">all projects</option></select>
         </div>
         <button id="talkBtn" class="btn">guided tour</button>
-      </div>
-      <!-- reader controls live in the console too — one chrome, not two -->
-      <div class="seg" id="readerSeg" hidden>
-        <div class="field">
-          <label>view</label>
-          <div class="themeseg" id="rView" role="group" aria-label="reader view">
-            <button type="button" id="rTrail" class="on">trail</button>
-            <button type="button" id="rMs">manuscript</button>
-          </div>
-        </div>
-        <div class="field">
-          <label>zoom</label>
-          <div class="themeseg">
-            <button type="button" id="rOut">−</button>
-            <button type="button" id="rFit"><span id="rzoom">100%</span></button>
-            <button type="button" id="rIn">+</button>
-          </div>
-        </div>
       </div>
       <div class="seg">
         <div class="field">

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -96,7 +96,16 @@
     </section>
 
     <aside id="readout"></aside>
-    <div id="legend"></div>
+
+    <!-- right rail: find a node by name, or narrow the galaxy to one project -->
+    <aside id="rail">
+      <div id="find">
+        <input id="findInput" type="search" placeholder="find a node…" autocomplete="off" spellcheck="false" />
+        <div id="findHits" hidden></div>
+      </div>
+      <div id="projects"></div>
+      <div id="legend"></div>
+    </aside>
 
     <section id="script" hidden>
       <div class="scriptcard">

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -11,6 +11,13 @@
   <body>
     <div id="graph"></div>
 
+    <!-- the reader: the same graph, read instead of surveyed -->
+    <section id="reader" hidden>
+      <div id="rcanvas"><div id="rworld"><svg id="rtrack"></svg></div></div>
+      <div id="manuscript"></div>
+      <div id="rhint">X — how far the reasoning ran · Y — depth: grounds below, consequences above</div>
+    </section>
+
     <header id="hud">
       <div class="seal" title="蛙 — kaeru, &quot;frog&quot;">蛙</div>
       <div class="wordmark">
@@ -27,6 +34,7 @@
           <select id="chainPick" class="ctl"></select>
         </div>
         <button id="chainPlay" class="btn go">replay</button>
+        <button id="chainRead" class="btn">read</button>
         <button id="chainReset" class="btn">reset</button>
       </div>
       <div class="seg">
@@ -46,6 +54,24 @@
           <select id="focus" class="ctl"><option value="">all projects</option></select>
         </div>
         <button id="talkBtn" class="btn">guided tour</button>
+      </div>
+      <!-- reader controls live in the console too — one chrome, not two -->
+      <div class="seg" id="readerSeg" hidden>
+        <div class="field">
+          <label>view</label>
+          <div class="themeseg" id="rView" role="group" aria-label="reader view">
+            <button type="button" id="rTrail" class="on">trail</button>
+            <button type="button" id="rMs">manuscript</button>
+          </div>
+        </div>
+        <div class="field">
+          <label>zoom</label>
+          <div class="themeseg">
+            <button type="button" id="rOut">−</button>
+            <button type="button" id="rFit"><span id="rzoom">100%</span></button>
+            <button type="button" id="rIn">+</button>
+          </div>
+        </div>
       </div>
       <div class="seg">
         <div class="field">

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
+import { createReader } from './reader.js'
 
 // ── helpers ───────────────────────────────────────────────────────────────
 const esc = (s) => String(s ?? '').replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]))
@@ -55,6 +56,7 @@ const THEMES = {
     hotLerp: new THREE.Color(0x1a120a), chainCur: 0x17171b, chainVisited: 0x8a5a10, chainLerp: 0.28,
   },
 }
+let reader = null          // the reader view; built once the graph is in (see below)
 let themePref = (() => { try { return localStorage.getItem('kaeru-viz-theme') || 'auto' } catch (_) { return 'auto' } })()
 const mql = matchMedia('(prefers-color-scheme: light)')
 const resolvedTheme = () => (themePref === 'auto' ? (mql.matches ? 'light' : 'dark') : themePref)
@@ -362,6 +364,7 @@ function showReadout(n, step, total) {
       <div class="tags">${meta}</div>
       <p>${esc(n.body || (n.redacted ? '⟨body redacted⟩' : (n.isHub ? 'A project cluster — hover its nodes to explore.' : '—')))}</p>
       ${n.isHub ? '' : `<div class="ts">asserted <b>${asserted}</b></div>`}
+      ${n.isHub ? '' : `<button class="btn go rd" data-read="${esc(n.id)}">read this trail →</button>`}
     </div>`
   readout.classList.add('show')
 }
@@ -505,6 +508,46 @@ data.chains.forEach((c, i) => { const o = document.createElement('option'); o.va
 $('chainPlay').addEventListener('click', () => { const c = data.chains[+chainPick.value || 0]; if (c) startReplay(c) })
 $('chainReset').addEventListener('click', resetChain)
 
+// ── reader: the same chain, read instead of surveyed ────────────────────────
+reader = createReader(data, { fmtDateTime })
+let readerOpen = false
+const readBtn = $('chainRead')
+async function setReader(on, nodeId) {
+  if (on) {
+    readBtn.textContent = '…'
+    const ok = nodeId
+      ? await reader.showNode(nodeId)
+      : await reader.show((data.chains[+chainPick.value || 0] || {}).id)
+    readBtn.textContent = ok ? 'galaxy' : 'read'
+    if (!ok) return
+    // if the node sat on a saved chain, let the picker follow the reader
+    const cid = reader.chainId()
+    if (cid) {
+      const i = data.chains.findIndex((c) => c.id === cid)
+      if (i >= 0 && +chainPick.value !== i) { chainPick.value = i; chainPick._sync && chainPick._sync() }
+    }
+  }
+  readerOpen = on
+  $('reader').hidden = !on
+  if (on) { setHover(-1); chip.style.display = 'none' }   // drop the galaxy's hover chip
+  readBtn.classList.toggle('go', on)
+  readBtn.textContent = on ? 'galaxy' : 'read'
+  // the panel stays; the rest of the galaxy's chrome belongs to the galaxy
+  $('readout').hidden = on
+  $('legend').hidden = on
+  $('readerSeg').hidden = !on            // reader controls join the console
+  $('colorMode').closest('.seg').hidden = on   // colour-by belongs to the galaxy
+  $('focus').closest('.seg').hidden = on
+}
+readBtn.addEventListener('click', () => setReader(!readerOpen))
+// the readout is rebuilt on every hover, so delegate rather than re-bind
+$('readout').addEventListener('click', (e) => {
+  const b = e.target.closest('[data-read]')
+  if (b) setReader(true, b.dataset.read)
+})
+// picking another chain while reading re-reads it
+chainPick.addEventListener('change', () => { if (readerOpen) setReader(true) })
+
 // custom archive-styled dropdowns over the (hidden) native selects
 function makeDropdown(sel) {
   sel.style.display = 'none'
@@ -639,6 +682,7 @@ function applyThemeToScene() {
   starMat.color.set(TH.star); starMat.opacity = TH.starOp
   ring.material.color.set(TH.ring)
   buildLegend(); applyVisuals()
+  if (reader) reader.redraw()
 }
 function setTheme(pref) {
   themePref = pref
@@ -673,7 +717,8 @@ function loop() {
   // auto-rotate only when idle — stop on hover, chain, focus, tour, camera tween
   controls.autoRotate = !(window.__rec && window.__rec.active) &&
     hovered < 0 && !chain.size && !focusInit && $('script').hidden && !tween
-  controls.update(); renderer.render(scene, camera)
+  controls.update()
+  if (!readerOpen) renderer.render(scene, camera)   // the reader covers the canvas
 }
 
 // recording hook — only present with ?rec, drives a deterministic seamless orbit

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -57,6 +57,7 @@ const THEMES = {
   },
 }
 let reader = null          // the reader view; built once the graph is in (see below)
+const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)')
 let themePref = (() => { try { return localStorage.getItem('kaeru-viz-theme') || 'auto' } catch (_) { return 'auto' } })()
 const mql = matchMedia('(prefers-color-scheme: light)')
 const resolvedTheme = () => (themePref === 'auto' ? (mql.matches ? 'light' : 'dark') : themePref)
@@ -597,18 +598,23 @@ function hex(c) { return '#' + c.getHexString() }
 // swatch tells you what a cluster's colour means, the row focuses it.
 function markActiveProject() {
   const el = $('projects'); if (!el) return
-  for (const row of el.children) row.classList.toggle('on', (row.dataset.init || null) === focusInit)
+  for (const row of el.children) {
+    const on = (row.dataset.init || null) === focusInit
+    row.classList.toggle('on', on); row.setAttribute('aria-pressed', String(on))
+  }
 }
 function buildProjects() {
   const el = $('projects')
   const rows = [...data.initiatives].sort((a, b) => (b.node_count || 0) - (a.node_count || 0))
   el.innerHTML =
-    `<div class="pr all${focusInit ? '' : ' on'}" data-init="">
+    `<button type="button" class="pr all${focusInit ? '' : ' on'}" data-init=""
+       aria-pressed="${focusInit ? 'false' : 'true'}">
        <span class="nm">all projects</span><span class="ct">${rawNodes.length}</span>
-       <span class="sw" style="background:transparent"></span></div>` +
-    rows.map((i) => `<div class="pr${focusInit === i.name ? ' on' : ''}" data-init="${esc(i.name)}" title="${esc(i.name)}">
+       <span class="sw" style="background:transparent"></span></button>` +
+    rows.map((i) => `<button type="button" class="pr${focusInit === i.name ? ' on' : ''}"
+       data-init="${esc(i.name)}" aria-pressed="${focusInit === i.name ? 'true' : 'false'}">
        <span class="nm">${esc(i.name)}</span><span class="ct">${i.node_count || 0}</span>
-       <span class="sw" style="background:${hex(initSwatch(i.name))}"></span></div>`).join('')
+       <span class="sw" style="background:${hex(initSwatch(i.name))}"></span></button>`).join('')
   for (const row of el.children) {
     row.addEventListener('click', () => {
       const name = row.dataset.init || null
@@ -733,18 +739,34 @@ function goToNode(i) {
   if (focusInit && n.init !== focusInit) setFocus(null)
   if (readerOpen) setReader(false)
   chain.clear(); nodes.forEach((x) => { x.__visited = false; x.__cur = false })
-  pinNode(i); flyTo(n.pos, 1100)
+  pinNode(i); flyTo(n.pos, reducedMotion.matches ? 0 : 1100)
+  say(`Showing ${n.name}`)
 }
-function closeHits() { findHits.hidden = true; hits = []; hitAt = -1 }
+function closeHits() {
+  findHits.hidden = true; hits = []; hitAt = -1
+  findInput.setAttribute('aria-expanded', 'false')
+  findInput.removeAttribute('aria-activedescendant')
+}
+function say(msg) { $('findStatus').textContent = msg }
 function renderHits() {
-  if (!hits.length) { findHits.innerHTML = '<div class="none">nothing found</div>'; findHits.hidden = false; return }
+  findInput.setAttribute('aria-expanded', 'true')
+  if (!hits.length) {
+    findHits.innerHTML = '<div class="none">nothing found</div>'
+    findHits.hidden = false
+    findInput.removeAttribute('aria-activedescendant')
+    say('No nodes found')
+    return
+  }
   findHits.innerHTML = hits.map((i, k) => {
     const n = nodes[i]
-    return `<div class="hit${k === hitAt ? ' on' : ''}" data-i="${i}">
+    return `<div class="hit${k === hitAt ? ' on' : ''}" id="hit-${i}" role="option"
+      aria-selected="${k === hitAt}" data-i="${i}">
       <span class="hn">${esc(n.name)}</span>
       <span class="hm">${esc(n.type)} · ${esc(n.init)}</span></div>`
   }).join('')
   findHits.hidden = false
+  if (hitAt >= 0) findInput.setAttribute('aria-activedescendant', `hit-${hits[hitAt]}`)
+  say(`${hits.length} node${hits.length === 1 ? '' : 's'} found`)
   for (const row of findHits.children) {
     if (!row.dataset.i) continue
     row.addEventListener('mousedown', (e) => { e.preventDefault(); goToNode(+row.dataset.i); closeHits(); findInput.blur() })
@@ -804,7 +826,7 @@ function loop() {
   bpGeo.attributes.position.needsUpdate = true
   if (tween) tween()
   // auto-rotate only when idle — stop on hover, chain, focus, tour, camera tween
-  controls.autoRotate = !(window.__rec && window.__rec.active) &&
+  controls.autoRotate = !reducedMotion.matches && !(window.__rec && window.__rec.active) &&
     hovered < 0 && !chain.size && !focusInit && $('script').hidden && !tween
   controls.update()
   if (!readerOpen) renderer.render(scene, camera)   // the reader covers the canvas

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -490,6 +490,7 @@ $('timePlay').addEventListener('click', () => (timeAnim ? stopTimeLapse() : star
 // ── focus ───────────────────────────────────────────────────────────────────
 function setFocus(name) {
   focusInit = name || null; $('focus').value = name || ''; $('focus')._sync && $('focus')._sync()
+  markActiveProject()
   pinned = -1; pinnedNb = new Set()
   applyVisuals()
   if (focusInit) frameCluster(focusInit, 1400); else frame(1200)
@@ -592,18 +593,41 @@ $('stats').innerHTML =
   `<div class="cell"><div class="n">${m.chain_count ?? data.chains.length}</div><div class="l">chains</div></div>` +
   `<div class="cell span">${fmtDate(T0)} — ${fmtDate(T1)}<span class="sub">one agent · ${Math.round((T1 - T0) / 86400)} days</span></div>`
 function hex(c) { return '#' + c.getHexString() }
+// The project list is the colour key AND the way to narrow the galaxy: the
+// swatch tells you what a cluster's colour means, the row focuses it.
+function markActiveProject() {
+  const el = $('projects'); if (!el) return
+  for (const row of el.children) row.classList.toggle('on', (row.dataset.init || null) === focusInit)
+}
+function buildProjects() {
+  const el = $('projects')
+  const rows = [...data.initiatives].sort((a, b) => (b.node_count || 0) - (a.node_count || 0))
+  el.innerHTML =
+    `<div class="pr all${focusInit ? '' : ' on'}" data-init="">
+       <span class="nm">all projects</span><span class="ct">${rawNodes.length}</span>
+       <span class="sw" style="background:transparent"></span></div>` +
+    rows.map((i) => `<div class="pr${focusInit === i.name ? ' on' : ''}" data-init="${esc(i.name)}" title="${esc(i.name)}">
+       <span class="nm">${esc(i.name)}</span><span class="ct">${i.node_count || 0}</span>
+       <span class="sw" style="background:${hex(initSwatch(i.name))}"></span></div>`).join('')
+  for (const row of el.children) {
+    row.addEventListener('click', () => {
+      const name = row.dataset.init || null
+      setFocus(focusInit === name ? null : name)   // clicking the active one clears it
+    })
+  }
+}
+
 function buildLegend() {
   const el = $('legend')
   if (colorMode === 'initiative') {
-    el.innerHTML = data.initiatives.slice(0, 8).map((i) => `${esc(i.name)} <span class="sw" style="background:${hex(initSwatch(i.name))}"></span>`).join('<br>') +
-      `<br><span style="opacity:.6">+ ${Math.max(0, data.initiatives.length - 8)} more</span>`
+    el.innerHTML = ''            // the project list above already carries the swatches
   } else if (colorMode === 'tier') {
     el.innerHTML = `operational (hippocampus) <span class="sw" style="background:${hex(modeColor(TIER_C, 'operational'))}"></span><br>archival (cortex) <span class="sw" style="background:${hex(modeColor(TIER_C, 'archival'))}"></span>`
   } else {
     el.innerHTML = ['core', 'hot', 'warm', 'cold', 'frozen'].map((l) => `${l} <span class="sw" style="background:${hex(modeColor(LAYER_C, l))}"></span>`).join('<br>')
   }
 }
-buildLegend()
+buildLegend(); buildProjects()
 
 // ── camera framing ───────────────────────────────────────────────────────────
 function boundsOf(filter) {
@@ -681,7 +705,7 @@ function applyThemeToScene() {
   bpPoints.material.color.set(TH.particle)
   starMat.color.set(TH.star); starMat.opacity = TH.starOp
   ring.material.color.set(TH.ring)
-  buildLegend(); applyVisuals()
+  buildLegend(); buildProjects(); applyVisuals()
   if (reader) reader.redraw()
 }
 function setTheme(pref) {
@@ -695,6 +719,71 @@ function setTheme(pref) {
 }
 for (const b of $('themeSeg').children) b.addEventListener('click', () => setTheme(b.dataset.t))
 mql.addEventListener('change', () => { if (themePref === 'auto') { TH = THEMES[resolvedTheme()]; applyThemeToScene() } })
+
+// ── find a node by name, instead of hunting for it in the galaxy ────────────
+const findInput = $('findInput'), findHits = $('findHits')
+let hits = [], hitAt = -1
+// nodes only: hubs are reachable from the project list above
+const searchable = nodes.filter((n) => !n.isHub)
+
+function goToNode(i) {
+  const n = nodes[i]; if (!n) return
+  // a hit must not stay invisible: lift the time filter and any project focus
+  if (!visible(n)) { timeFilter = Infinity; timeEl.value = 100; timeLabel('— full graph —') }
+  if (focusInit && n.init !== focusInit) setFocus(null)
+  if (readerOpen) setReader(false)
+  chain.clear(); nodes.forEach((x) => { x.__visited = false; x.__cur = false })
+  pinNode(i); flyTo(n.pos, 1100)
+}
+function closeHits() { findHits.hidden = true; hits = []; hitAt = -1 }
+function renderHits() {
+  if (!hits.length) { findHits.innerHTML = '<div class="none">nothing found</div>'; findHits.hidden = false; return }
+  findHits.innerHTML = hits.map((i, k) => {
+    const n = nodes[i]
+    return `<div class="hit${k === hitAt ? ' on' : ''}" data-i="${i}">
+      <span class="hn">${esc(n.name)}</span>
+      <span class="hm">${esc(n.type)} · ${esc(n.init)}</span></div>`
+  }).join('')
+  findHits.hidden = false
+  for (const row of findHits.children) {
+    if (!row.dataset.i) continue
+    row.addEventListener('mousedown', (e) => { e.preventDefault(); goToNode(+row.dataset.i); closeHits(); findInput.blur() })
+  }
+}
+function runFind() {
+  const q = findInput.value.trim().toLowerCase()
+  if (q.length < 2) { closeHits(); return }
+  const starts = [], has = []
+  for (let i = 0; i < searchable.length && starts.length + has.length < 200; i++) {
+    const nm = searchable[i].name.toLowerCase()
+    const at = nm.indexOf(q)
+    if (at === 0) starts.push(idx.get(searchable[i].id))
+    else if (at > 0) has.push(idx.get(searchable[i].id))
+  }
+  hits = [...starts, ...has].slice(0, 40)
+  hitAt = hits.length ? 0 : -1
+  renderHits()
+}
+findInput.addEventListener('input', runFind)
+findInput.addEventListener('focus', () => { if (findInput.value.trim().length >= 2) runFind() })
+findInput.addEventListener('blur', () => setTimeout(closeHits, 120))
+findInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') { findInput.value = ''; closeHits(); findInput.blur(); return }
+  if (!hits.length) return
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    e.preventDefault()
+    hitAt = (hitAt + (e.key === 'ArrowDown' ? 1 : hits.length - 1)) % hits.length
+    renderHits()
+    findHits.children[hitAt]?.scrollIntoView({ block: 'nearest' })
+  } else if (e.key === 'Enter' && hitAt >= 0) {
+    e.preventDefault(); goToNode(hits[hitAt]); closeHits(); findInput.blur()
+  }
+})
+// "/" focuses the search, the way every other tool does it
+addEventListener('keydown', (e) => {
+  if (e.key !== '/' || e.target.tagName === 'INPUT' || !$('script').hidden) return
+  e.preventDefault(); findInput.focus(); findInput.select()
+})
 
 // ── loop ─────────────────────────────────────────────────────────────────────
 addEventListener('resize', () => { camera.aspect = innerWidth / innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth, innerHeight) })

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -538,13 +538,16 @@ async function setReader(on, nodeId) {
   readBtn.classList.toggle('go', on)
   readBtn.textContent = on ? 'galaxy' : 'read'
   // the panel stays; the rest of the galaxy's chrome belongs to the galaxy
+  // Reading is its own room. Colour-by, focus, time-lapse, node search and the
+  // project list are all instruments for surveying the galaxy; none of them
+  // mean anything while you are reading a trail, so the whole chrome steps out.
+  $('panel').hidden = on
+  $('rail').hidden = on
   $('readout').hidden = on
-  $('legend').hidden = on
-  $('readerSeg').hidden = !on            // reader controls join the console
-  $('colorMode').closest('.seg').hidden = on   // colour-by belongs to the galaxy
-  $('focus').closest('.seg').hidden = on
+  $('hud').hidden = on
 }
 readBtn.addEventListener('click', () => setReader(!readerOpen))
+$('rBack').addEventListener('click', () => setReader(false))
 // the readout is rebuilt on every hover, so delegate rather than re-bind
 $('readout').addEventListener('click', (e) => {
   const b = e.target.closest('[data-read]')

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -548,6 +548,13 @@ async function setReader(on, nodeId) {
 }
 readBtn.addEventListener('click', () => setReader(!readerOpen))
 $('rBack').addEventListener('click', () => setReader(false))
+// Escape leaves the reader — the reader covers the whole page, and every other
+// overlay here already closes that way. (Backspace steps back inside it.)
+addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape' || !readerOpen) return
+  if (/^(INPUT|TEXTAREA)$/.test(e.target.tagName)) return
+  e.preventDefault(); setReader(false)
+})
 // the readout is rebuilt on every hover, so delegate rather than re-bind
 $('readout').addEventListener('click', (e) => {
   const b = e.target.closest('[data-read]')
@@ -706,7 +713,7 @@ $('talkBtn').addEventListener('click', enterScript)
 $('scriptNext').addEventListener('click', nextScene)
 $('scriptPrev').addEventListener('click', prevScene)
 $('scriptExit').addEventListener('click', exitScript)
-addEventListener('keydown', (e) => { if ($('script').hidden) return; if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); nextScene() } else if (e.key === 'ArrowLeft') { e.preventDefault(); prevScene() } else if (e.key === 'Escape') exitScript() })
+addEventListener('keydown', (e) => { if ($('script').hidden) return; if (/^(INPUT|TEXTAREA)$/.test(e.target.tagName)) return; if (e.key === 'ArrowRight' || e.key === ' ') { e.preventDefault(); nextScene() } else if (e.key === 'ArrowLeft') { e.preventDefault(); prevScene() } else if (e.key === 'Escape') exitScript() })
 
 // ── theme (dark / light / auto) ──────────────────────────────────────────────
 function applyThemeToScene() {
@@ -809,7 +816,8 @@ findInput.addEventListener('keydown', (e) => {
 })
 // "/" focuses the search, the way every other tool does it
 addEventListener('keydown', (e) => {
-  if (e.key !== '/' || e.target.tagName === 'INPUT' || !$('script').hidden) return
+  // the rail is gone while reading, so focusing its input would be a no-op
+  if (e.key !== '/' || e.target.tagName === 'INPUT' || !$('script').hidden || readerOpen) return
   e.preventDefault(); findInput.focus(); findInput.select()
 })
 

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -517,11 +517,14 @@ const readBtn = $('chainRead')
 async function setReader(on, nodeId) {
   if (on) {
     readBtn.textContent = '…'
+    // Unhide BEFORE laying out: the reader measures card heights to stack its
+    // lanes, and a `display:none` subtree measures zero.
+    $('reader').hidden = false
     const ok = nodeId
       ? await reader.showNode(nodeId)
       : await reader.show((data.chains[+chainPick.value || 0] || {}).id)
     readBtn.textContent = ok ? 'galaxy' : 'read'
-    if (!ok) return
+    if (!ok) { $('reader').hidden = true; return }
     // if the node sat on a saved chain, let the picker follow the reader
     const cid = reader.chainId()
     if (cid) {

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -343,12 +343,18 @@ export function createReader(data, { fmtDateTime }) {
         links.forEach((l) => {
           const t = N[l.o]; if (!t) return
           const label = (REL[l.t] || [l.t, l.t])[l.dir === 'out' ? 0 : 1]
-          html += `<a><span class="r">${l.dir === 'out' ? '↳ ' : '↰ '}${esc(label)}</span><span class="n">${esc(deslug(t.name))}</span></a>`
+          html += `<button type="button" class="mlink" data-to="${t.id}"
+            aria-label="Read ${esc(deslug(t.name))} — ${esc(label)}">
+            <span class="r">${l.dir === 'out' ? '↳ ' : '↰ '}${esc(label)}</span>
+            <span class="n">${esc(deslug(t.name))}</span></button>`
         })
         html += '</aside>'
       }
     })
     sheet.innerHTML = html + '</div>'
+    sheet.querySelectorAll('.mlink').forEach((b) => {
+      b.onclick = () => { openNode(b.dataset.to); setView('manuscript') }
+    })
   }
 
   // ── pan / zoom ──────────────────────────────────────────────────────────

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -1,0 +1,421 @@
+// The reader — the galaxy's second view.
+//
+// The galaxy answers *where* a thought sits; the reader answers *what it says*.
+// It runs on the same feed, the same tokens and the same theme control, and it
+// is driven by the same chain picker, so the two views are one instrument.
+//
+// Layout grammar: **X is how far the reasoning was carried** (depth of
+// derivation) and **Y is which line of inquiry** (lane). A plain chain is just
+// a one-lane DAG, so a linear trail and a branching deep-research share one
+// layout instead of two.
+
+// same layer ramp the galaxy's readout bar uses
+const LAYER_ACCENT = { core: '#caa24a', hot: '#c8402e', warm: '#7e96cf', cold: '#6f7da0', frozen: '#8a8578' }
+const REL = {
+  derived_from: ['derived from', 'grounds this'], refers_to: ['refers to', 'referenced here'],
+  supersedes: ['supersedes', 'superseded by'], verifies: ['verifies', 'verified in'],
+  causal: ['led to', 'follows from'], part_of: ['part of', 'contains'],
+  temporal: ['before', 'after'], contradicts: ['contradicts', 'contradicts'],
+  blocks: ['blocks', 'blocked by'], targets: ['targets', 'targeted by'],
+}
+const STEP_DX = 760, LANE_DY = 430, SPINE_Y = 560, X0 = 560
+
+const $ = (id) => document.getElementById(id)
+const esc = (s) => (s || '').replace(/[&<>]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[m]))
+const deslug = (n) => (n || '').replace(/-20\d\d-\d\d-\d\d$/, '').replace(/-[0-9a-f]{6}$/, '').replace(/-/g, ' ')
+const clamp = (v, a, b) => Math.min(b, Math.max(a, v))
+
+export function createReader(data, { fmtDateTime }) {
+  const world = $('rworld'), track = $('rtrack'), canvas = $('rcanvas'), sheet = $('manuscript')
+  const N = {}, ADJ = {}
+  data.nodes.filter((n) => n.type !== 'chain').forEach((n) => { N[n.id] = { ...n }; ADJ[n.id] = [] })
+  for (const e of data.edges) {
+    if (!N[e.src] || !N[e.dst]) continue
+    ADJ[e.src].push({ o: e.dst, t: e.type, dir: 'out' })
+    ADJ[e.dst].push({ o: e.src, t: e.type, dir: 'in' })
+  }
+
+  let chain = null, steps = [], POS = {}, lanes = 0, shared = new Map(), research = new Set()
+  let tx = 60, ty = 40, scale = 0.62, view = 'trail'
+  let bodiesLoaded = false
+
+  // ── text ────────────────────────────────────────────────────────────────
+  const inline = (t) => esc(t)
+    .replace(/\[\[([^\]]+)\]\]/g, (m, x) => `<span class="rmark">${deslug(x)}</span>`)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+  const paras = (b) => (b || '').trim().split(/\n{2,}/)
+    .map((p) => `<p>${inline(p.trim()).replace(/\n/g, '<br>')}</p>`).join('')
+  const clip = (b, n) => {
+    const t = (b || '').replace(/\s+/g, ' ').trim()
+    return t.length > n ? inline(t.slice(0, n).replace(/\s\S*$/, '')) + '…' : inline(t)
+  }
+  const when = (n) => (n.created_secs ? fmtDateTime(n.created_secs) : '—')
+  const h = (s) => { const d = document.createElement('div'); d.innerHTML = s.trim(); return d.firstChild }
+
+  // The galaxy only needs excerpts; a reader needs the whole body. Pay for the
+  // heavier payload once, the first time the reader is actually opened.
+  async function loadBodies() {
+    if (bodiesLoaded) return
+    bodiesLoaded = true
+    for (const url of ['/graph.json?bodies=true', './graph.json?bodies=true']) {
+      try {
+        const r = await fetch(url)
+        if (!r.ok) continue
+        const g = await r.json()
+        for (const n of g.nodes) if (N[n.id] && n.body) N[n.id].body = n.body
+        return
+      } catch (_) { /* fall through to the baked snapshot */ }
+    }
+  }
+
+  // ── layout: derivation DAG, lanes by path decomposition ─────────────────
+  const derivEdges = () => {
+    const out = []
+    for (const id in ADJ) for (const l of ADJ[id]) if (l.dir === 'out' && l.t === 'derived_from') out.push({ from: l.o, to: id })
+    return out
+  }
+  function layout() {
+    POS = {}
+    const E = derivEdges(), parents = {}
+    research = new Set(steps.map((s) => s.id))
+    // pull in whatever the chain's own steps derive from or feed into
+    for (let hop = 0; hop < 2; hop++) {
+      for (const e of E) {
+        if (research.has(e.from)) research.add(e.to)
+        if (research.has(e.to)) research.add(e.from)
+      }
+    }
+    for (const e of E) if (research.has(e.from) && research.has(e.to)) (parents[e.to] = parents[e.to] || []).push(e.from)
+
+    const depth = {}
+    const visit = (id, seen) => {
+      if (depth[id] != null) return depth[id]
+      if (seen.has(id)) return 0
+      seen.add(id)
+      const ps = (parents[id] || []).filter((p) => research.has(p))
+      depth[id] = ps.length ? Math.max(...ps.map((p) => visit(p, seen))) + 1 : 0
+      return depth[id]
+    }
+    ;[...research].forEach((id) => visit(id, new Set()))
+
+    // A lane must be a REAL chain of parent→child. Slotting by depth instead
+    // drops unrelated threads onto one rail, and the rail then draws a
+    // continuity that does not exist in the graph.
+    const byDepth = {}
+    ;[...research].forEach((id) => { (byDepth[depth[id]] = byDepth[depth[id]] || []).push(id) })
+    const lane = {}, passedOn = new Set()
+    let next = 0
+    Object.keys(byDepth).map(Number).sort((a, b) => a - b).forEach((d) => {
+      byDepth[d].sort((a, b) => (N[a]?.created_secs || 0) - (N[b]?.created_secs || 0))
+      byDepth[d].forEach((id) => {
+        const p = (parents[id] || []).find((pp) => lane[pp] != null && !passedOn.has(pp))
+        if (p != null) { lane[id] = lane[p]; passedOn.add(p) } else lane[id] = next++
+      })
+    })
+    const onChain = new Set(steps.map((s) => s.id))
+    const chainLanes = new Set([...onChain].map((id) => lane[id]).filter((v) => v != null))
+    const order = [...new Set(Object.values(lane))]
+      .sort((a, b) => (chainLanes.has(b) ? 1 : 0) - (chainLanes.has(a) ? 1 : 0) || a - b)
+    const rank = {}; order.forEach((l, i) => { rank[l] = i })
+    lanes = order.length
+    ;[...research].forEach((id) => {
+      POS[id] = { x: X0 + depth[id] * STEP_DX, y: SPINE_Y - 70 + rank[lane[id]] * LANE_DY, d: depth[id], lane: rank[lane[id]] }
+    })
+    // anything several lines lean on is stated once, as the trail's bedrock
+    const touch = new Map()
+    ;[...research].forEach((id) => {
+      for (const l of ADJ[id] || []) {
+        if (research.has(l.o)) continue
+        if (!touch.has(l.o)) touch.set(l.o, { n: 0, steps: [] })
+        const t = touch.get(l.o); t.n++; t.steps.push(id)
+      }
+    })
+    shared = new Map([...touch].filter(([, v]) => v.n > 1))
+  }
+
+  // ── build ───────────────────────────────────────────────────────────────
+  function buildTrail() {
+    world.querySelectorAll('.step,.sat,.thesis,.lanetag,.bedlabel').forEach((e) => e.remove())
+    if (!steps.length) return
+    layout()
+    const first = steps[0], last = steps[steps.length - 1]
+    world.appendChild(h(`<div class="thesis" style="left:40px;top:${SPINE_Y - 40}px">
+      <div class="kind">${chain.adhoc ? 'node' : research.size > steps.length ? 'deep research' : 'reasoning chain'}
+        · ${research.size} ${research.size === 1 ? 'node' : 'nodes'}
+        · ${lanes} ${lanes === 1 ? 'line' : 'lines'}</div>
+      <h1>${esc(deslug(chain.name))}</h1>
+      <p class="lede">${chain.adhoc
+        ? (research.size > 1
+          ? 'Opened from the galaxy — this node and what it was derived from.'
+          : 'Opened from the galaxy. This node stands on its own: nothing derives from it and it derives from nothing yet.')
+        : lanes > 1
+          ? 'A worked trail that forks: one line carried on, the others went their own way.'
+          : 'A worked trail of reasoning — each step is a node of memory, its links lead back to what it stands on.'}</p>
+      <div class="meta"><b>${when(first)}</b> — first step<br><b>${when(last)}</b> — last step<br>
+        ${(first.initiatives || []).length ? `initiative <b>${esc(first.initiatives[0])}</b>` : ''}</div>
+    </div>`))
+
+    const onChain = new Set(steps.map((s) => s.id))
+    ;[...research].sort((a, b) => POS[a].d - POS[b].d).forEach((id) => {
+      const n = N[id]; if (!n || !POS[id]) return
+      const { x, y } = POS[id], acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
+      const main = onChain.has(id), idx = steps.findIndex((s) => s.id === id)
+      // You opened the reader to read: the body starts OPEN. Folding is the
+      // opt-in, for when a long trail needs to be scanned rather than read.
+      const long = (n.body || '').length > 380
+      const brief = long ? n.body.slice(0, 380).replace(/\s\S*$/, '') + '…' : (n.body || '')
+      const el = h(`<div class="step${main ? '' : ' aside'}" data-id="${id}" style="left:${x}px;top:${y}px;--acc:${acc}">
+        <div class="pad">
+          <div class="meta"><span class="num">${main ? String(idx + 1).padStart(2, '0') : '—'}</span>
+            <span class="s">·</span><span class="t">${esc(n.type)}</span><span class="s">·</span>
+            <span>${esc(n.tier)}</span><span class="s">·</span><span>${esc(n.layer)}</span></div>
+          <h2>${esc(deslug(n.name))}</h2>
+          <div class="body">${paras(n.body || '')}</div>
+          <div class="foot"><span class="when">asserted <b>${when(n)}</b></span>
+            ${long ? '<button class="more">collapse</button>' : ''}</div>
+        </div></div>`)
+      world.appendChild(el)
+      const more = el.querySelector('.more')
+      if (more) more.onclick = () => {
+        const folded = more.dataset.folded === '1'
+        el.querySelector('.body').innerHTML = paras(folded ? n.body : brief)
+        more.dataset.folded = folded ? '' : '1'
+        more.textContent = folded ? 'collapse' : 'expand'
+        drawTrack()
+      }
+      // one consequence hung above the node, if it has one outside the research
+      const above = (ADJ[id] || []).filter((l) => !research.has(l.o) && !shared.has(l.o) && l.dir === 'in' && l.t === 'refers_to')
+      placeSat(above.slice(0, 1), x, y - 300, id)
+    })
+
+    labelLanes(onChain)
+    placeBedrock()
+    drawTrack()
+    // Open at a readable size on the head of the trail rather than fitting the
+    // whole research — a deep one fits only by shrinking the text to nothing.
+    requestAnimationFrame(frameStart)
+  }
+  function placeSat(list, sx, y, ofId) {
+    list.forEach((l, j) => {
+      const n = N[l.o]; if (!n) return
+      const acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
+      const label = (REL[l.t] || [l.t, l.t])[l.dir === 'out' ? 0 : 1]
+      const el = h(`<div class="sat" data-id="${n.id}" data-of="${ofId}"
+          style="left:${sx + 8 + j * 310}px;top:${y}px;--acc:${acc}" title="read this node">
+        <div class="rel">${esc(label)}</div><h3>${esc(deslug(n.name))}</h3>
+        <p class="ex">${clip(n.body, 110)}</p>
+        <div class="tag">${esc(n.type)} · ${esc(n.tier)}</div></div>`)
+      el.onclick = () => openNode(n.id)
+      world.appendChild(el)
+    })
+  }
+  function labelLanes(onChain) {
+    const heads = {}
+    Object.entries(POS).forEach(([id, p]) => { if (!heads[p.lane] || p.d < POS[heads[p.lane]].d) heads[p.lane] = id })
+    Object.entries(heads).forEach(([ln, id]) => {
+      const p = POS[id], main = onChain.has(id)
+      // above its own first card, never beside it — to the left is where the
+      // title page sits, and the tag used to collide with it
+      world.appendChild(h(`<div class="lanetag${main ? ' main' : ''}" style="left:${p.x}px;top:${p.y - 30}px">
+        <span class="ln">${String.fromCharCode(65 + +ln)}</span>${main ? 'main trail' : 'side line'}</div>`))
+    })
+  }
+  function placeBedrock() {
+    if (!shared.size) return
+    const xs = Object.values(POS).map((p) => p.x)
+    const y = SPINE_Y - 70 + lanes * LANE_DY + 120, total = shared.size
+    const mid = (Math.min(...xs) + Math.max(...xs) + 540) / 2, left = mid - (total * 310) / 2
+    world.appendChild(h(`<div class="bedlabel" style="left:${left}px;top:${y - 30}px">
+      shared ground — more than one line rests on this</div>`))
+    ;[...shared].forEach(([id, v], i) => {
+      const n = N[id]; if (!n) return
+      const acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
+      const el = h(`<div class="sat bed" data-id="${id}" data-steps="${v.steps.join(',')}"
+          style="left:${left + i * 310}px;top:${y}px;--acc:${acc}" title="read this node">
+        <div class="rel">shared ground · ${v.n}×</div><h3>${esc(deslug(n.name))}</h3>
+        <p class="ex">${clip(n.body, 130)}</p>
+        <div class="tag">${esc(n.type)} · ${esc(n.tier)}</div></div>`)
+      el.onclick = () => openNode(id)
+      world.appendChild(el)
+    })
+  }
+
+  // ── the track follows real edges, so a fork looks like a fork ────────────
+  function drawTrack() {
+    if (!steps.length) { track.innerHTML = ''; return }
+    const cs = getComputedStyle(document.documentElement)
+    const acc = cs.getPropertyValue('--seal').trim()
+    const quiet = cs.getPropertyValue('--line-2').trim()
+    const faint = cs.getPropertyValue('--line').trim()
+    const box = (id) => {
+      const el = world.querySelector(`.step[data-id="${id}"]`); if (!el) return null
+      const x = parseFloat(el.style.left), y = parseFloat(el.style.top)
+      return { x, y, w: el.offsetWidth, h: el.offsetHeight, cy: y + 34 }
+    }
+    let d = ''
+    // each lane's rail runs only as far as that line actually goes
+    const rail = {}
+    Object.entries(POS).forEach(([id, p]) => {
+      const el = world.querySelector(`.step[data-id="${id}"]`); if (!el) return
+      const L = rail[p.lane] = rail[p.lane] || { y: p.y + 34, min: Infinity, max: -Infinity }
+      L.min = Math.min(L.min, p.x); L.max = Math.max(L.max, p.x + el.offsetWidth)
+    })
+    Object.values(rail).forEach((L) => {
+      if (!isFinite(L.min)) return
+      d += `<line x1="${L.min - 60}" y1="${L.y}" x2="${L.max + 60}" y2="${L.y}" stroke="${quiet}" stroke-width="1" opacity=".5"/>`
+    })
+    derivEdges().forEach((e) => {
+      const a = box(e.from), b = box(e.to); if (!a || !b) return
+      const x1 = a.x + a.w, y1 = a.cy, x2 = b.x - 10, y2 = b.cy
+      const dx = Math.max(60, (x2 - x1) * 0.45)
+      d += `<path d="M ${x1} ${y1} C ${x1 + dx} ${y1}, ${x2 - dx} ${y2}, ${x2} ${y2}" fill="none" stroke="${acc}" stroke-width="1.5" opacity=".6"/>`
+      d += `<path d="M ${x2 - 6} ${y2 - 4} l 6 4 l -6 4" fill="none" stroke="${acc}" stroke-width="1.5" opacity=".6"/>`
+      d += `<circle cx="${x1}" cy="${y1}" r="3.5" fill="${acc}" opacity=".75"/>`
+    })
+    world.querySelectorAll('.sat.bed').forEach((bd) => {
+      const bx = parseFloat(bd.style.left) + 145, by = parseFloat(bd.style.top)
+      ;(bd.dataset.steps || '').split(',').filter(Boolean).forEach((sid) => {
+        const st = box(sid); if (!st) return
+        const sx = st.x + st.w / 2, sy = st.y + st.h
+        d += `<path d="M ${sx} ${sy} C ${sx} ${sy + 80}, ${bx} ${by - 80}, ${bx} ${by}" fill="none" stroke="${faint}" stroke-width="1" stroke-dasharray="3 5"/>`
+      })
+    })
+    world.querySelectorAll('.sat:not(.bed)').forEach((s) => {
+      const of = box(s.dataset.of); if (!of) return
+      const sx = parseFloat(s.style.left) + 40, sy = parseFloat(s.style.top) + s.offsetHeight
+      d += `<path d="M ${sx} ${sy} L ${sx} ${of.y}" stroke="${faint}" stroke-width="1" stroke-dasharray="3 4"/>`
+    })
+    track.innerHTML = d
+  }
+
+  // ── manuscript: the same trail as one continuous read ───────────────────
+  function buildManuscript() {
+    if (!steps.length) { sheet.innerHTML = ''; return }
+    let html = `<div class="ms"><div class="kind">${chain.adhoc ? 'node' : 'reasoning chain'}</div>
+      <h1>${esc(deslug(chain.name))}</h1>
+      <p class="lede">${esc(chain.body || (chain.adhoc ? 'A single node, read in full.' : 'A worked trail of reasoning, read end to end.'))}</p>
+      <div class="byline">${steps.length} ${steps.length === 1 ? 'step' : 'steps'} · ${when(steps[0])}${steps.length > 1 ? ' — ' + when(steps[steps.length - 1]) : ''}</div>`
+    steps.forEach((n, i) => {
+      const acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
+      html += `<section style="--acc:${acc}">
+        <div class="snum">STEP ${String(i + 1).padStart(2, '0')} · ${esc(n.type)} · ${esc(n.tier)}</div>
+        <h2>${esc(deslug(n.name))}</h2>
+        <div class="when">asserted <b>${when(n)}</b></div>
+        <div class="prose">${paras(n.body || '—')}</div></section>`
+      const links = (ADJ[n.id] || []).filter((l) => !steps.some((s) => s.id === l.o)).slice(0, 3)
+      if (links.length) {
+        html += `<aside class="marg" style="--acc:${acc}"><div class="mtitle">in the margin</div>`
+        links.forEach((l) => {
+          const t = N[l.o]; if (!t) return
+          const label = (REL[l.t] || [l.t, l.t])[l.dir === 'out' ? 0 : 1]
+          html += `<a><span class="r">${l.dir === 'out' ? '↳ ' : '↰ '}${esc(label)}</span><span class="n">${esc(deslug(t.name))}</span></a>`
+        })
+        html += '</aside>'
+      }
+    })
+    sheet.innerHTML = html + '</div>'
+  }
+
+  // ── pan / zoom ──────────────────────────────────────────────────────────
+  function applyTransform() {
+    world.style.transform = `translate(${tx}px,${ty}px) scale(${scale})`
+    const g = 28 * scale
+    canvas.style.backgroundSize = `${g}px ${g}px`
+    canvas.style.backgroundPosition = `${tx}px ${ty}px`
+    const z = $('rzoom'); if (z) z.textContent = Math.round(scale * 100) + '%'
+  }
+  /** Frame the start of the trail at a size you can actually read. */
+  function frameStart() {
+    const TOP = 96, BOTTOM = 130
+    scale = 0.72
+    tx = 40
+    ty = TOP + (innerHeight - TOP - BOTTOM) / 2 - (SPINE_Y + 90) * scale
+    applyTransform()
+  }
+  function fit() {
+    const els = [...world.children].filter((e) => e.tagName !== 'svg' && e.offsetWidth)
+    if (!els.length) return
+    let mnx = 1e9, mny = 1e9, mxx = -1e9, mxy = -1e9
+    els.forEach((e) => {
+      const x = parseFloat(e.style.left), y = parseFloat(e.style.top)
+      mnx = Math.min(mnx, x); mny = Math.min(mny, y)
+      mxx = Math.max(mxx, x + e.offsetWidth); mxy = Math.max(mxy, y + e.offsetHeight)
+    })
+    const pad = 120, TOP = 96, BOTTOM = 130      // masthead above, console below
+    const availH = innerHeight - TOP - BOTTOM
+    scale = clamp(Math.min(innerWidth / (mxx - mnx + pad * 2), availH / (mxy - mny + pad * 2)), 0.2, 1.2)
+    tx = innerWidth / 2 - (mnx + (mxx - mnx) / 2) * scale
+    ty = TOP + availH / 2 - (mny + (mxy - mny) / 2) * scale
+    applyTransform()
+  }
+  let panning = false, sx = 0, sy = 0
+  canvas.addEventListener('pointerdown', (e) => {
+    if (e.target.closest('#rdock')) return
+    panning = true; sx = e.clientX - tx; sy = e.clientY - ty; canvas.classList.add('grabbing')
+  })
+  addEventListener('pointermove', (e) => { if (!panning) return; tx = e.clientX - sx; ty = e.clientY - sy; applyTransform() })
+  addEventListener('pointerup', () => { panning = false; canvas.classList.remove('grabbing') })
+  canvas.addEventListener('wheel', (e) => {
+    e.preventDefault()
+    const ns = clamp(scale * Math.exp(-e.deltaY * 0.0012), 0.2, 1.8)
+    const r = canvas.getBoundingClientRect(), mx = e.clientX - r.left, my = e.clientY - r.top
+    tx = mx - (mx - tx) * (ns / scale); ty = my - (my - ty) * (ns / scale); scale = ns; applyTransform()
+  }, { passive: false })
+  const zoomBy = (f) => {
+    const ns = clamp(scale * f, 0.2, 1.8), cx = innerWidth / 2, cy = innerHeight / 2
+    tx = cx - (cx - tx) * (ns / scale); ty = cy - (cy - ty) * (ns / scale); scale = ns; applyTransform()
+  }
+
+  function setView(v) {
+    view = v
+    sheet.classList.toggle('on', v === 'manuscript')
+    canvas.style.display = v === 'manuscript' ? 'none' : ''
+    $('rhint').hidden = v === 'manuscript'
+    $('rTrail').classList.toggle('on', v === 'trail')
+    $('rMs').classList.toggle('on', v === 'manuscript')
+  }
+  $('rTrail').onclick = () => setView('trail')
+  $('rMs').onclick = () => setView('manuscript')
+  $('rIn').onclick = () => zoomBy(1.2)
+  $('rOut').onclick = () => zoomBy(1 / 1.2)
+  $('rFit').onclick = fit
+
+  /** Read a single node: its own chain if it has one, else the node plus what
+   *  it was derived from. Used by the galaxy's readout and by every card the
+   *  trail shows as a link. */
+  function openNode(id) {
+    if (!N[id]) return false
+    const c = data.chains.find((x) => (x.members || []).includes(id))
+    return c ? render(c, c.members) : render({ name: N[id].name, adhoc: true }, [id])
+  }
+  function render(c, members) {
+    chain = c
+    steps = members.map((id) => N[id]).filter(Boolean).sort((a, b) => (a.created_secs || 0) - (b.created_secs || 0))
+    if (!steps.length) return false
+    buildTrail(); buildManuscript(); setView(view)
+    return true
+  }
+
+  return {
+    /** Load a chain (by the picker's value) and render both views. */
+    async show(chainId) {
+      await loadBodies()
+      const c = data.chains.find((x) => x.id === chainId) || data.chains.find((x) => x.name === chainId)
+      return c ? render(c, c.members) : false
+    },
+
+    /** Open on a single node — the way in from the galaxy. If the node sits on
+     *  a saved chain, read that trail; otherwise make an ad-hoc one from the
+     *  node, which the layout then grows along its derivation links. */
+    async showNode(id) {
+      await loadBodies()
+      return openNode(id)
+    },
+
+    /** Which chain is on the desk, if any (so the picker can follow along). */
+    chainId: () => chain && chain.id,
+    /** Re-tint the SVG track when the theme flips. */
+    redraw: drawTrack,
+    hasChain: () => !!chain,
+  }
+}

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -162,8 +162,8 @@ export function createReader(data, { fmtDateTime }) {
       const main = onChain.has(id), idx = steps.findIndex((s) => s.id === id)
       // You opened the reader to read: the body starts OPEN. Folding is the
       // opt-in, for when a long trail needs to be scanned rather than read.
-      const long = (n.body || '').length > 380
-      const brief = long ? n.body.slice(0, 380).replace(/\s\S*$/, '') + '…' : (n.body || '')
+      // the body is always rendered whole — CSS caps what is visible, so the
+      // trail keeps its shape and `expand` only lifts the cap
       const el = h(`<div class="step${main ? '' : ' aside'}" data-id="${id}" style="left:${x}px;top:${y}px;--acc:${acc}">
         <div class="pad">
           <div class="meta"><span class="num">${main ? String(idx + 1).padStart(2, '0') : '—'}</span>
@@ -171,23 +171,27 @@ export function createReader(data, { fmtDateTime }) {
             <span>${esc(n.tier)}</span><span class="s">·</span><span>${esc(n.layer)}</span></div>
           <h2>${esc(deslug(n.name))}</h2>
           <div class="body">${paras(n.body || '')}</div>
-          <div class="foot"><span class="when">asserted <b>${when(n)}</b></span>
-            ${long ? '<button class="more">collapse</button>' : ''}</div>
+          <div class="foot"><span class="when">asserted <b>${when(n)}</b></span></div>
         </div></div>`)
       world.appendChild(el)
-      const more = el.querySelector('.more')
-      if (more) more.onclick = () => {
-        const folded = more.dataset.folded === '1'
-        el.querySelector('.body').innerHTML = paras(folded ? n.body : brief)
-        more.dataset.folded = folded ? '' : '1'
-        more.textContent = folded ? 'collapse' : 'expand'
-        drawTrack()
+      // only offer the control when there is genuinely more to see
+      const body = el.querySelector('.body')
+      if (body.scrollHeight > body.clientHeight + 4) {
+        body.classList.add('clipped')
+        const more = h('<button type="button" class="more">expand</button>')
+        el.querySelector('.foot').appendChild(more)
+        more.onclick = () => {
+          const open = el.classList.toggle('open')
+          more.textContent = open ? 'collapse' : 'expand'
+          restack(); drawTrack()
+        }
       }
-      // one consequence hung above the node, if it has one outside the research
-      const above = (ADJ[id] || []).filter((l) => !research.has(l.o) && !shared.has(l.o) && l.dir === 'in' && l.t === 'refers_to')
-      placeSat(above.slice(0, 1), x, y - 300, id)
     })
 
+    // A lane's height is whatever its tallest card turned out to be. Spacing
+    // lanes by a fixed constant worked only while bodies were clipped; with
+    // them open a long card runs straight through the lane below it.
+    restack()
     labelLanes(onChain)
     placeBedrock()
     drawTrack()
@@ -195,6 +199,32 @@ export function createReader(data, { fmtDateTime }) {
     // whole research — a deep one fits only by shrinking the text to nothing.
     requestAnimationFrame(frameStart)
   }
+  /** Stack lanes by measured height, then hang each node's satellite above it. */
+  function restack() {
+    const byLane = {}
+    Object.entries(POS).forEach(([id, p]) => {
+      const el = world.querySelector(`.step[data-id="${id}"]`); if (!el) return
+      ;(byLane[p.lane] = byLane[p.lane] || []).push({ id, p, el })
+    })
+    const GAP = 150, SAT = 260      // between lanes, and room for a satellite above
+    let top = SPINE_Y - 70
+    Object.keys(byLane).map(Number).sort((a, b) => a - b).forEach((ln) => {
+      const row = byLane[ln]
+      const hasSat = row.some(({ id }) => satOf(id).length)
+      if (hasSat) top += SAT
+      row.forEach(({ p, el }) => { p.y = top; el.style.top = `${top}px` })
+      top += Math.max(...row.map(({ el }) => el.offsetHeight)) + GAP
+    })
+    // satellites only now, when the card they hang off has its final position
+    Object.entries(POS).forEach(([id, p]) => {
+      const list = satOf(id); if (!list.length) return
+      const el = world.querySelector(`.step[data-id="${id}"]`); if (!el) return
+      placeSat(list.slice(0, 1), p.x, p.y - 240, id)
+    })
+  }
+  const satOf = (id) => (ADJ[id] || []).filter((l) =>
+    !research.has(l.o) && !shared.has(l.o) && l.dir === 'in' && l.t === 'refers_to')
+
   function placeSat(list, sx, y, ofId) {
     list.forEach((l, j) => {
       const n = N[l.o]; if (!n) return
@@ -213,8 +243,10 @@ export function createReader(data, { fmtDateTime }) {
   function labelLanes(onChain) {
     const heads = {}
     Object.entries(POS).forEach(([id, p]) => { if (!heads[p.lane] || p.d < POS[heads[p.lane]].d) heads[p.lane] = id })
+    // exactly one lane is the authored trail: the one carrying its first step
+    const mainLane = steps.length && POS[steps[0].id] ? POS[steps[0].id].lane : 0
     Object.entries(heads).forEach(([ln, id]) => {
-      const p = POS[id], main = onChain.has(id)
+      const p = POS[id], main = +ln === mainLane
       // above its own first card, never beside it — to the left is where the
       // title page sits, and the tag used to collide with it
       world.appendChild(h(`<div class="lanetag${main ? ' main' : ''}" style="left:${p.x}px;top:${p.y - 30}px">
@@ -224,7 +256,12 @@ export function createReader(data, { fmtDateTime }) {
   function placeBedrock() {
     if (!shared.size) return
     const xs = Object.values(POS).map((p) => p.x)
-    const y = SPINE_Y - 70 + lanes * LANE_DY + 120, total = shared.size
+    let lowest = SPINE_Y
+    Object.entries(POS).forEach(([id, p]) => {
+      const el = world.querySelector(`.step[data-id="${id}"]`)
+      lowest = Math.max(lowest, p.y + (el ? el.offsetHeight : 300))
+    })
+    const y = lowest + 150, total = shared.size
     const mid = (Math.min(...xs) + Math.max(...xs) + 540) / 2, left = mid - (total * 310) / 2
     world.appendChild(h(`<div class="bedlabel" style="left:${left}px;top:${y - 30}px">
       shared ground — more than one line rests on this</div>`))

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -23,6 +23,25 @@ const STEP_DX = 470, LANE_DY = 300, SPINE_Y = 300, X0 = 120
 const $ = (id) => document.getElementById(id)
 const esc = (s) => (s || '').replace(/[&<>]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[m]))
 const deslug = (n) => (n || '').replace(/-20\d\d-\d\d-\d\d$/, '').replace(/-[0-9a-f]{6}$/, '').replace(/-/g, ' ')
+// The trailing hex is noise almost always — but it is the ONLY thing telling
+// two same-named nodes apart, and stripping it makes them look like one node
+// drawn twice. Put it back for exactly those.
+const disambiguate = (nodes) => {
+  const seen = new Map()
+  nodes.forEach((n) => {
+    if (!n) return
+    const t = deslug(n.name)
+    seen.set(t, (seen.get(t) || 0) + 1)
+  })
+  const label = {}
+  nodes.forEach((n) => {
+    if (!n) return
+    const t = deslug(n.name)
+    const tag = seen.get(t) > 1 ? (n.name.match(/-([0-9a-f]{6})$/) || [])[1] : null
+    label[n.id] = tag ? `${t} · ${tag}` : t
+  })
+  return label
+}
 const clamp = (v, a, b) => Math.min(b, Math.max(a, v))
 
 export function createReader(data, { fmtDateTime }) {
@@ -135,10 +154,13 @@ export function createReader(data, { fmtDateTime }) {
   }
 
   // ── build ───────────────────────────────────────────────────────────────
+  let TITLE = {}                // display titles, disambiguated within the view
   function buildTrail() {
     world.querySelectorAll('.step,.sat,.lanetag,.bedlabel').forEach((e) => e.remove())
     if (!steps.length) return
     layout()
+    TITLE = disambiguate([...research].map((id) => N[id])
+      .concat([...shared.keys()].map((id) => N[id])))
     const onChain = new Set(steps.map((s) => s.id))
     ;[...research].sort((a, b) => POS[a].d - POS[b].d).forEach((id) => {
       const n = N[id]; if (!n || !POS[id]) return
@@ -148,12 +170,12 @@ export function createReader(data, { fmtDateTime }) {
       // opt-in, for when a long trail needs to be scanned rather than read.
       const el = h(`<button type="button" class="step${main ? '' : ' aside'}" data-id="${id}"
           style="left:${x}px;top:${y}px;--acc:${acc}"
-          aria-label="Read ${esc(deslug(n.name))}">
+          aria-label="Read ${esc(TITLE[id] || deslug(n.name))}">
         <span class="meta"><span class="num">${main ? String(idx + 1).padStart(2, '0') : '—'}</span>
           <span class="s">·</span><span class="t">${esc(n.type)}</span>
           <span class="s">·</span><span>${esc(n.layer)}</span></span>
         <span class="h2-like"></span>
-        <h2>${esc(deslug(n.name))}</h2>
+        <h2>${esc(TITLE[id] || deslug(n.name))}</h2>
         <p class="gist">${clip(n.body, 150)}</p>
         <span class="when">${when(n)}</span>
       </button>`)
@@ -206,8 +228,8 @@ export function createReader(data, { fmtDateTime }) {
       const label = (REL[l.t] || [l.t, l.t])[l.dir === 'out' ? 0 : 1]
       const el = h(`<button type="button" class="sat" data-id="${n.id}" data-of="${ofId}"
           style="left:${sx + 8 + j * 310}px;top:${y}px;--acc:${acc}"
-          aria-label="Read ${esc(deslug(n.name))} — ${esc(label)}">
-        <span class="rel">${esc(label)}</span><span class="h3">${esc(deslug(n.name))}</span>
+          aria-label="Read ${esc(TITLE[n.id] || deslug(n.name))} — ${esc(label)}">
+        <span class="rel">${esc(label)}</span><span class="h3">${esc(TITLE[n.id] || deslug(n.name))}</span>
         <span class="ex">${clip(n.body, 110)}</span>
         <span class="tag">${esc(n.type)} · ${esc(n.tier)}</span></button>`)
       el.onclick = () => openNode(n.id)
@@ -245,8 +267,8 @@ export function createReader(data, { fmtDateTime }) {
       const acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
       const el = h(`<button type="button" class="sat bed" data-id="${id}" data-steps="${v.steps.join(',')}"
           style="left:${left + i * 310}px;top:${y}px;--acc:${acc}"
-          aria-label="Read ${esc(deslug(n.name))} — shared ground for ${v.n} steps">
-        <span class="rel">shared ground · ${v.n}×</span><span class="h3">${esc(deslug(n.name))}</span>
+          aria-label="Read ${esc(TITLE[id] || deslug(n.name))} — shared ground for ${v.n} steps">
+        <span class="rel">shared ground · ${v.n}×</span><span class="h3">${esc(TITLE[id] || deslug(n.name))}</span>
         <span class="ex">${clip(n.body, 130)}</span>
         <span class="tag">${esc(n.type)} · ${esc(n.tier)}</span></button>`)
       el.onclick = () => openNode(id)
@@ -335,7 +357,7 @@ export function createReader(data, { fmtDateTime }) {
       const main = onChain.has(n.id)
       html += `<section data-id="${n.id}" style="--acc:${acc}">
         <div class="snum">${main ? `STEP ${String(i + 1).padStart(2, '0')}` : 'SIDE LINE'} · ${esc(n.type)} · ${esc(n.tier)}</div>
-        <h2>${esc(deslug(n.name))}</h2>
+        <h2>${esc(TITLE[n.id] || deslug(n.name))}</h2>
         <div class="when">asserted <b>${when(n)}</b></div>
         <div class="prose">${paras(n.body || '—')}</div></section>`
       const links = (ADJ[n.id] || []).filter((l) => !onChain.has(l.o)).slice(0, 3)
@@ -470,6 +492,12 @@ export function createReader(data, { fmtDateTime }) {
     steps = members.map((id) => N[id]).filter(Boolean).sort((a, b) => (a.created_secs || 0) - (b.created_secs || 0))
     if (!steps.length) return false
     buildTrail(); buildManuscript(); setView(view)
+    // Lanes are stacked from measured card heights. Measuring before the web
+    // fonts land sizes them with the fallback face, and every card grows when
+    // Spectral arrives — so lay it out again once the real metrics exist.
+    if (document.fonts && document.fonts.status !== 'loaded') {
+      document.fonts.ready.then(() => { if (chain && steps.length) relayout() })
+    }
     return true
   }
 

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -36,6 +36,7 @@ export function createReader(data, { fmtDateTime }) {
   }
 
   let chain = null, steps = [], POS = {}, lanes = 0, shared = new Map(), research = new Set()
+  let hist = []                 // trail of what was read before this
   let tx = 60, ty = 40, scale = 0.62, view = 'trail'
   let bodiesLoaded = false
 
@@ -415,16 +416,54 @@ export function createReader(data, { fmtDateTime }) {
     $('rTrail').classList.toggle('on', v === 'trail')
     $('rMs').classList.toggle('on', v === 'manuscript')
   }
+  const prevBtn = $('rPrev')
+  if (prevBtn) prevBtn.onclick = goBack
+  addEventListener('keydown', (e) => {
+    if ($('reader').hidden) return
+    const typing = /^(INPUT|TEXTAREA)$/.test(e.target.tagName)
+    if (typing) return
+    if (e.key === 'Backspace' || (e.altKey && e.key === 'ArrowLeft')) { e.preventDefault(); goBack() }
+  })
   $('rTrail').onclick = () => setView('trail')
   $('rMs').onclick = () => setView('manuscript')
 
   /** Read a single node: its own chain if it has one, else the node plus what
    *  it was derived from. Used by the galaxy's readout and by every card the
    *  trail shows as a link. */
-  function openNode(id) {
+  /** A descriptor of what is on the desk, enough to come back to it. */
+  const mark = () => (!chain ? null : chain.adhoc ? { node: steps[0] && steps[0].id } : { chain: chain.id })
+  function restore(m) {
+    if (!m) return false
+    if (m.chain) {
+      const c = data.chains.find((x) => x.id === m.chain)
+      return c ? render(c, c.members) : false
+    }
+    return m.node && N[m.node] ? render({ name: N[m.node].name, adhoc: true }, [m.node]) : false
+  }
+  function openNode(id, remember = true) {
     if (!N[id]) return false
+    const from = mark()
     const c = data.chains.find((x) => (x.members || []).includes(id))
-    return c ? render(c, c.members) : render({ name: N[id].name, adhoc: true }, [id])
+    const ok = c ? render(c, c.members) : render({ name: N[id].name, adhoc: true }, [id])
+    if (ok && remember && from && JSON.stringify(from) !== JSON.stringify(mark())) hist.push(from)
+    syncBack()
+    return ok
+  }
+  function goBack() {
+    const m = hist.pop()
+    if (!m) return false
+    const ok = restore(m)
+    syncBack()
+    return ok
+  }
+  function syncBack() {
+    const b = $('rPrev'); if (!b) return
+    b.hidden = !hist.length
+    const last = hist[hist.length - 1]
+    const name = !last ? '' : last.chain
+      ? (data.chains.find((x) => x.id === last.chain) || {}).name
+      : (N[last.node] || {}).name
+    b.title = name ? `Back to ${deslug(name)}` : ''
   }
   function render(c, members) {
     chain = c
@@ -439,6 +478,7 @@ export function createReader(data, { fmtDateTime }) {
     async show(chainId) {
       await loadBodies()
       const c = data.chains.find((x) => x.id === chainId) || data.chains.find((x) => x.name === chainId)
+      hist = []; syncBack()
       return c ? render(c, c.members) : false
     },
 
@@ -447,8 +487,13 @@ export function createReader(data, { fmtDateTime }) {
      *  node, which the layout then grows along its derivation links. */
     async showNode(id) {
       await loadBodies()
-      return openNode(id)
+      hist = []; syncBack()
+      return openNode(id, false)
     },
+
+    /** Step back to whatever was being read before the last link. */
+    back: goBack,
+    canBack: () => hist.length > 0,
 
     /** Which chain is on the desk, if any (so the picker can follow along). */
     chainId: () => chain && chain.id,

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -18,7 +18,7 @@ const REL = {
   temporal: ['before', 'after'], contradicts: ['contradicts', 'contradicts'],
   blocks: ['blocks', 'blocked by'], targets: ['targets', 'targeted by'],
 }
-const STEP_DX = 760, LANE_DY = 430, SPINE_Y = 560, X0 = 560
+const STEP_DX = 470, LANE_DY = 300, SPINE_Y = 300, X0 = 120
 
 const $ = (id) => document.getElementById(id)
 const esc = (s) => (s || '').replace(/[&<>]/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[m]))
@@ -135,26 +135,9 @@ export function createReader(data, { fmtDateTime }) {
 
   // ── build ───────────────────────────────────────────────────────────────
   function buildTrail() {
-    world.querySelectorAll('.step,.sat,.thesis,.lanetag,.bedlabel').forEach((e) => e.remove())
+    world.querySelectorAll('.step,.sat,.lanetag,.bedlabel').forEach((e) => e.remove())
     if (!steps.length) return
     layout()
-    const first = steps[0], last = steps[steps.length - 1]
-    world.appendChild(h(`<div class="thesis" style="left:40px;top:${SPINE_Y - 40}px">
-      <div class="kind">${chain.adhoc ? 'node' : research.size > steps.length ? 'deep research' : 'reasoning chain'}
-        · ${research.size} ${research.size === 1 ? 'node' : 'nodes'}
-        · ${lanes} ${lanes === 1 ? 'line' : 'lines'}</div>
-      <h1>${esc(deslug(chain.name))}</h1>
-      <p class="lede">${chain.adhoc
-        ? (research.size > 1
-          ? 'Opened from the galaxy — this node and what it was derived from.'
-          : 'Opened from the galaxy. This node stands on its own: nothing derives from it and it derives from nothing yet.')
-        : lanes > 1
-          ? 'A worked trail that forks: one line carried on, the others went their own way.'
-          : 'A worked trail of reasoning — each step is a node of memory, its links lead back to what it stands on.'}</p>
-      <div class="meta"><b>${when(first)}</b> — first step<br><b>${when(last)}</b> — last step<br>
-        ${(first.initiatives || []).length ? `initiative <b>${esc(first.initiatives[0])}</b>` : ''}</div>
-    </div>`))
-
     const onChain = new Set(steps.map((s) => s.id))
     ;[...research].sort((a, b) => POS[a].d - POS[b].d).forEach((id) => {
       const n = N[id]; if (!n || !POS[id]) return
@@ -162,30 +145,19 @@ export function createReader(data, { fmtDateTime }) {
       const main = onChain.has(id), idx = steps.findIndex((s) => s.id === id)
       // You opened the reader to read: the body starts OPEN. Folding is the
       // opt-in, for when a long trail needs to be scanned rather than read.
-      // the body is always rendered whole — CSS caps what is visible, so the
-      // trail keeps its shape and `expand` only lifts the cap
-      const el = h(`<div class="step${main ? '' : ' aside'}" data-id="${id}" style="left:${x}px;top:${y}px;--acc:${acc}">
-        <div class="pad">
-          <div class="meta"><span class="num">${main ? String(idx + 1).padStart(2, '0') : '—'}</span>
-            <span class="s">·</span><span class="t">${esc(n.type)}</span><span class="s">·</span>
-            <span>${esc(n.tier)}</span><span class="s">·</span><span>${esc(n.layer)}</span></div>
-          <h2>${esc(deslug(n.name))}</h2>
-          <div class="body">${paras(n.body || '')}</div>
-          <div class="foot"><span class="when">asserted <b>${when(n)}</b></span></div>
-        </div></div>`)
+      const el = h(`<button type="button" class="step${main ? '' : ' aside'}" data-id="${id}"
+          style="left:${x}px;top:${y}px;--acc:${acc}"
+          aria-label="Read ${esc(deslug(n.name))}">
+        <span class="meta"><span class="num">${main ? String(idx + 1).padStart(2, '0') : '—'}</span>
+          <span class="s">·</span><span class="t">${esc(n.type)}</span>
+          <span class="s">·</span><span>${esc(n.layer)}</span></span>
+        <span class="h2-like"></span>
+        <h2>${esc(deslug(n.name))}</h2>
+        <p class="gist">${clip(n.body, 150)}</p>
+        <span class="when">${when(n)}</span>
+      </button>`)
       world.appendChild(el)
-      // only offer the control when there is genuinely more to see
-      const body = el.querySelector('.body')
-      if (body.scrollHeight > body.clientHeight + 4) {
-        body.classList.add('clipped')
-        const more = h('<button type="button" class="more">expand</button>')
-        el.querySelector('.foot').appendChild(more)
-        more.onclick = () => {
-          const open = el.classList.toggle('open')
-          more.textContent = open ? 'collapse' : 'expand'
-          relayout()
-        }
-      }
+      el.onclick = () => readAt(id)
     })
 
     // A lane's height is whatever its tallest card turned out to be. Spacing
@@ -207,7 +179,7 @@ export function createReader(data, { fmtDateTime }) {
       const el = world.querySelector(`.step[data-id="${id}"]`); if (!el) return
       ;(byLane[p.lane] = byLane[p.lane] || []).push({ id, p, el })
     })
-    const GAP = 110, SAT = 250      // between lanes, and room for a satellite above
+    const GAP = 64, SAT = 150       // between lanes, and room for a satellite above
     let top = SPINE_Y - 70
     Object.keys(byLane).map(Number).sort((a, b) => a - b).forEach((ln) => {
       const row = byLane[ln]
@@ -217,7 +189,7 @@ export function createReader(data, { fmtDateTime }) {
     })
     Object.entries(POS).forEach(([id, p]) => {
       const list = satOf(id); if (!list.length) return
-      placeSat(list.slice(0, 1), p.x, p.y - 240, id)
+      placeSat(list.slice(0, 1), p.x, p.y - 130, id)
     })
     labelLanes(new Set(steps.map((x) => x.id)))
     placeBedrock()
@@ -263,7 +235,7 @@ export function createReader(data, { fmtDateTime }) {
       const el = world.querySelector(`.step[data-id="${id}"]`)
       lowest = Math.max(lowest, p.y + (el ? el.offsetHeight : 300))
     })
-    const y = lowest + 150, total = shared.size
+    const y = lowest + 90, total = shared.size
     const mid = (Math.min(...xs) + Math.max(...xs) + 540) / 2, left = mid - (total * 310) / 2
     world.appendChild(h(`<div class="bedlabel" style="left:${left}px;top:${y - 30}px">
       shared ground — more than one line rests on this</div>`))
@@ -330,20 +302,42 @@ export function createReader(data, { fmtDateTime }) {
   }
 
   // ── manuscript: the same trail as one continuous read ───────────────────
+  /** The map is for shape; the words live in the reading view. */
+  function readAt(id) {
+    setView('manuscript')
+    // Point at the step once now and once after the sheet has been given a box.
+    // Not via requestAnimationFrame: it does not reliably fire when the view
+    // that is about to paint was display:none a moment ago.
+    const point = () => {
+      const sec = sheet.querySelector(`section[data-id="${id}"]`)
+      if (!sec) return
+      sheet.querySelectorAll('section.here').forEach((e) => e.classList.remove('here'))
+      sec.classList.add('here')
+      const top = sec.getBoundingClientRect().top - sheet.getBoundingClientRect().top
+      sheet.scrollTo({ top: sheet.scrollTop + top - 96, behavior: reduceMotion() ? 'auto' : 'smooth' })
+    }
+    point(); setTimeout(point, 60)
+  }
+  const reduceMotion = () => matchMedia('(prefers-reduced-motion: reduce)').matches
+
   function buildManuscript() {
     if (!steps.length) { sheet.innerHTML = ''; return }
     let html = `<div class="ms"><div class="kind">${chain.adhoc ? 'node' : 'reasoning chain'}</div>
       <h1>${esc(deslug(chain.name))}</h1>
       <p class="lede">${esc(chain.body || (chain.adhoc ? 'A single node, read in full.' : 'A worked trail of reasoning, read end to end.'))}</p>
       <div class="byline">${steps.length} ${steps.length === 1 ? 'step' : 'steps'} · ${when(steps[0])}${steps.length > 1 ? ' — ' + when(steps[steps.length - 1]) : ''}</div>`
-    steps.forEach((n, i) => {
+    const onChain = new Set(steps.map((x) => x.id))
+    const order = [...steps, ...[...research].filter((id) => !onChain.has(id)).map((id) => N[id])
+      .filter(Boolean).sort((a, b) => (a.created_secs || 0) - (b.created_secs || 0))]
+    order.forEach((n, i) => {
       const acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
-      html += `<section style="--acc:${acc}">
-        <div class="snum">STEP ${String(i + 1).padStart(2, '0')} · ${esc(n.type)} · ${esc(n.tier)}</div>
+      const main = onChain.has(n.id)
+      html += `<section data-id="${n.id}" style="--acc:${acc}">
+        <div class="snum">${main ? `STEP ${String(i + 1).padStart(2, '0')}` : 'SIDE LINE'} · ${esc(n.type)} · ${esc(n.tier)}</div>
         <h2>${esc(deslug(n.name))}</h2>
         <div class="when">asserted <b>${when(n)}</b></div>
         <div class="prose">${paras(n.body || '—')}</div></section>`
-      const links = (ADJ[n.id] || []).filter((l) => !steps.some((s) => s.id === l.o)).slice(0, 3)
+      const links = (ADJ[n.id] || []).filter((l) => !onChain.has(l.o)).slice(0, 3)
       if (links.length) {
         html += `<aside class="marg" style="--acc:${acc}"><div class="mtitle">in the margin</div>`
         links.forEach((l) => {
@@ -367,11 +361,9 @@ export function createReader(data, { fmtDateTime }) {
   }
   /** Frame the start of the trail at a size you can actually read. */
   function frameStart() {
-    const TOP = 96, BOTTOM = 130
-    scale = 0.72
-    tx = 40
-    ty = TOP + (innerHeight - TOP - BOTTOM) / 2 - (SPINE_Y + 90) * scale
-    applyTransform()
+    // the map is meant to be taken in, so start from a fit rather than a
+    // fixed zoom — the stations are legible even well under 100%
+    fit()
   }
   function fit() {
     const els = [...world.children].filter((e) => e.tagName !== 'svg' && e.offsetWidth)
@@ -382,9 +374,9 @@ export function createReader(data, { fmtDateTime }) {
       mnx = Math.min(mnx, x); mny = Math.min(mny, y)
       mxx = Math.max(mxx, x + e.offsetWidth); mxy = Math.max(mxy, y + e.offsetHeight)
     })
-    const pad = 120, TOP = 96, BOTTOM = 130      // masthead above, console below
+    const pad = 90, TOP = 76, BOTTOM = 60        // the reader's own bar, and the hint
     const availH = innerHeight - TOP - BOTTOM
-    scale = clamp(Math.min(innerWidth / (mxx - mnx + pad * 2), availH / (mxy - mny + pad * 2)), 0.2, 1.2)
+    scale = clamp(Math.min(innerWidth / (mxx - mnx + pad * 2), availH / (mxy - mny + pad * 2)), 0.34, 1)
     tx = innerWidth / 2 - (mnx + (mxx - mnx) / 2) * scale
     ty = TOP + availH / 2 - (mny + (mxy - mny) / 2) * scale
     applyTransform()
@@ -408,18 +400,17 @@ export function createReader(data, { fmtDateTime }) {
   }
 
   function setView(v) {
+    const nm = $('rname'); if (nm && chain) nm.textContent = deslug(chain.name)
+    const hint = $('rhint'); if (hint) hint.textContent =
+      v === 'manuscript' ? 'reading the trail end to end' : 'click a step to read it'
     view = v
     sheet.classList.toggle('on', v === 'manuscript')
     canvas.style.display = v === 'manuscript' ? 'none' : ''
-    $('rhint').hidden = v === 'manuscript'
     $('rTrail').classList.toggle('on', v === 'trail')
     $('rMs').classList.toggle('on', v === 'manuscript')
   }
   $('rTrail').onclick = () => setView('trail')
   $('rMs').onclick = () => setView('manuscript')
-  $('rIn').onclick = () => zoomBy(1.2)
-  $('rOut').onclick = () => zoomBy(1 / 1.2)
-  $('rFit').onclick = fit
 
   /** Read a single node: its own chain if it has one, else the node plus what
    *  it was derived from. Used by the galaxy's readout and by every card the

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -76,14 +76,14 @@ export function createReader(data, { fmtDateTime }) {
   // heavier payload once, the first time the reader is actually opened.
   async function loadBodies() {
     if (bodiesLoaded) return
-    bodiesLoaded = true
     for (const url of ['/graph.json?bodies=true', './graph.json?bodies=true']) {
       try {
         const r = await fetch(url)
         if (!r.ok) continue
         const g = await r.json()
         for (const n of g.nodes) if (N[n.id] && n.body) N[n.id].body = n.body
-        return
+        bodiesLoaded = true   // only once it actually arrived: a transient
+        return                // failure must leave the next open free to retry
       } catch (_) { /* fall through to the baked snapshot */ }
     }
   }
@@ -106,6 +106,14 @@ export function createReader(data, { fmtDateTime }) {
       }
     }
     for (const e of E) if (research.has(e.from) && research.has(e.to)) (parents[e.to] = parents[e.to] || []).push(e.from)
+    // Not every chain links its steps with `derived_from` — plenty are just a
+    // sequence. Without a parent every step sits at depth 0, so the trail
+    // stacks into a column of "side lines" that claims ten lines of inquiry
+    // where there is one. The chain's own order is the fallback derivation.
+    for (let i = 1; i < steps.length; i++) {
+      const id = steps[i].id
+      if (!(parents[id] || []).length) parents[id] = [steps[i - 1].id]
+    }
 
     const depth = {}
     const visit = (id, seen) => {
@@ -236,6 +244,14 @@ export function createReader(data, { fmtDateTime }) {
       world.appendChild(el)
     })
   }
+  // A..Z, then AA, AB… — a wide research has more lines than the alphabet
+  const laneLetter = (i) => {
+    let out = ''
+    for (let n = i; ; n = Math.floor(n / 26) - 1) {
+      out = String.fromCharCode(65 + (n % 26)) + out
+      if (n < 26) return out
+    }
+  }
   function labelLanes(onChain) {
     const heads = {}
     Object.entries(POS).forEach(([id, p]) => { if (!heads[p.lane] || p.d < POS[heads[p.lane]].d) heads[p.lane] = id })
@@ -247,7 +263,7 @@ export function createReader(data, { fmtDateTime }) {
       // title page sits, and the tag used to collide with it
       // clear of the card it names: the tag is 18px tall, so sit it above that
       world.appendChild(h(`<div class="lanetag${main ? ' main' : ''}" style="left:${p.x}px;top:${p.y - 30}px">
-        <span class="ln">${String.fromCharCode(65 + +ln)}</span> · ${main ? 'main trail' : 'side line'}</div>`))
+        <span class="ln">${laneLetter(+ln)}</span> · ${main ? 'main trail' : 'side line'}</div>`))
     })
   }
   function placeBedrock() {
@@ -489,7 +505,8 @@ export function createReader(data, { fmtDateTime }) {
   }
   function render(c, members) {
     chain = c
-    steps = members.map((id) => N[id]).filter(Boolean).sort((a, b) => (a.created_secs || 0) - (b.created_secs || 0))
+    steps = (members || []).map((id) => N[id]).filter(Boolean)
+      .sort((a, b) => (a.created_secs || 0) - (b.created_secs || 0))
     if (!steps.length) return false
     buildTrail(); buildManuscript(); setView(view)
     // Lanes are stacked from measured card heights. Measuring before the web

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -200,11 +200,12 @@ export function createReader(data, { fmtDateTime }) {
       const n = N[l.o]; if (!n) return
       const acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
       const label = (REL[l.t] || [l.t, l.t])[l.dir === 'out' ? 0 : 1]
-      const el = h(`<div class="sat" data-id="${n.id}" data-of="${ofId}"
-          style="left:${sx + 8 + j * 310}px;top:${y}px;--acc:${acc}" title="read this node">
-        <div class="rel">${esc(label)}</div><h3>${esc(deslug(n.name))}</h3>
-        <p class="ex">${clip(n.body, 110)}</p>
-        <div class="tag">${esc(n.type)} · ${esc(n.tier)}</div></div>`)
+      const el = h(`<button type="button" class="sat" data-id="${n.id}" data-of="${ofId}"
+          style="left:${sx + 8 + j * 310}px;top:${y}px;--acc:${acc}"
+          aria-label="Read ${esc(deslug(n.name))} — ${esc(label)}">
+        <span class="rel">${esc(label)}</span><span class="h3">${esc(deslug(n.name))}</span>
+        <span class="ex">${clip(n.body, 110)}</span>
+        <span class="tag">${esc(n.type)} · ${esc(n.tier)}</span></button>`)
       el.onclick = () => openNode(n.id)
       world.appendChild(el)
     })
@@ -230,11 +231,12 @@ export function createReader(data, { fmtDateTime }) {
     ;[...shared].forEach(([id, v], i) => {
       const n = N[id]; if (!n) return
       const acc = LAYER_ACCENT[n.layer] || 'var(--dim)'
-      const el = h(`<div class="sat bed" data-id="${id}" data-steps="${v.steps.join(',')}"
-          style="left:${left + i * 310}px;top:${y}px;--acc:${acc}" title="read this node">
-        <div class="rel">shared ground · ${v.n}×</div><h3>${esc(deslug(n.name))}</h3>
-        <p class="ex">${clip(n.body, 130)}</p>
-        <div class="tag">${esc(n.type)} · ${esc(n.tier)}</div></div>`)
+      const el = h(`<button type="button" class="sat bed" data-id="${id}" data-steps="${v.steps.join(',')}"
+          style="left:${left + i * 310}px;top:${y}px;--acc:${acc}"
+          aria-label="Read ${esc(deslug(n.name))} — shared ground for ${v.n} steps">
+        <span class="rel">shared ground · ${v.n}×</span><span class="h3">${esc(deslug(n.name))}</span>
+        <span class="ex">${clip(n.body, 130)}</span>
+        <span class="tag">${esc(n.type)} · ${esc(n.tier)}</span></button>`)
       el.onclick = () => openNode(id)
       world.appendChild(el)
     })

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -183,7 +183,7 @@ export function createReader(data, { fmtDateTime }) {
         more.onclick = () => {
           const open = el.classList.toggle('open')
           more.textContent = open ? 'collapse' : 'expand'
-          restack(); drawTrack()
+          relayout()
         }
       }
     })
@@ -191,36 +191,37 @@ export function createReader(data, { fmtDateTime }) {
     // A lane's height is whatever its tallest card turned out to be. Spacing
     // lanes by a fixed constant worked only while bodies were clipped; with
     // them open a long card runs straight through the lane below it.
-    restack()
-    labelLanes(onChain)
-    placeBedrock()
-    drawTrack()
+    relayout()
     // Open at a readable size on the head of the trail rather than fitting the
     // whole research — a deep one fits only by shrinking the text to nothing.
     requestAnimationFrame(frameStart)
   }
-  /** Stack lanes by measured height, then hang each node's satellite above it. */
-  function restack() {
+  /** Re-lay the trail around whatever height the cards currently have.
+   *  Everything that hangs off a card — its satellite, its lane tag, the
+   *  shared ground below — is discarded and re-placed, because a card that
+   *  grew leaves all of them pointing at where it used to be. */
+  function relayout() {
+    world.querySelectorAll('.sat,.lanetag,.bedlabel').forEach((e) => e.remove())
     const byLane = {}
     Object.entries(POS).forEach(([id, p]) => {
       const el = world.querySelector(`.step[data-id="${id}"]`); if (!el) return
       ;(byLane[p.lane] = byLane[p.lane] || []).push({ id, p, el })
     })
-    const GAP = 150, SAT = 260      // between lanes, and room for a satellite above
+    const GAP = 110, SAT = 250      // between lanes, and room for a satellite above
     let top = SPINE_Y - 70
     Object.keys(byLane).map(Number).sort((a, b) => a - b).forEach((ln) => {
       const row = byLane[ln]
-      const hasSat = row.some(({ id }) => satOf(id).length)
-      if (hasSat) top += SAT
+      if (row.some(({ id }) => satOf(id).length)) top += SAT
       row.forEach(({ p, el }) => { p.y = top; el.style.top = `${top}px` })
       top += Math.max(...row.map(({ el }) => el.offsetHeight)) + GAP
     })
-    // satellites only now, when the card they hang off has its final position
     Object.entries(POS).forEach(([id, p]) => {
       const list = satOf(id); if (!list.length) return
-      const el = world.querySelector(`.step[data-id="${id}"]`); if (!el) return
       placeSat(list.slice(0, 1), p.x, p.y - 240, id)
     })
+    labelLanes(new Set(steps.map((x) => x.id)))
+    placeBedrock()
+    drawTrack()
   }
   const satOf = (id) => (ADJ[id] || []).filter((l) =>
     !research.has(l.o) && !shared.has(l.o) && l.dir === 'in' && l.t === 'refers_to')
@@ -249,8 +250,9 @@ export function createReader(data, { fmtDateTime }) {
       const p = POS[id], main = +ln === mainLane
       // above its own first card, never beside it — to the left is where the
       // title page sits, and the tag used to collide with it
+      // clear of the card it names: the tag is 18px tall, so sit it above that
       world.appendChild(h(`<div class="lanetag${main ? ' main' : ''}" style="left:${p.x}px;top:${p.y - 30}px">
-        <span class="ln">${String.fromCharCode(65 + +ln)}</span>${main ? 'main trail' : 'side line'}</div>`))
+        <span class="ln">${String.fromCharCode(65 + +ln)}</span> · ${main ? 'main trail' : 'side line'}</div>`))
     })
   }
   function placeBedrock() {

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -36,7 +36,7 @@
 * { box-sizing: border-box; }
 html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
   font-family: var(--serif); overflow: hidden;
-  transition: background .3s ease, color .3s ease; }
+  transition: background-color .3s ease, color .3s ease; }
 [hidden] { display: none !important; }
 #graph { position: fixed; inset: 0; }
 
@@ -184,6 +184,13 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 #readout .ts b { color: var(--gold); font-weight: 400; }
 
 /* ── legend ───────────────────────────────────────────── */
+/* keyboard focus is visible everywhere; pointer users still see nothing */
+:focus-visible { outline: 2px solid var(--seal); outline-offset: 2px; border-radius: 2px; }
+
+/* for text only assistive tech should read */
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
+
 /* ── right rail: find a node, or narrow to one project ─── */
 #rail { position: fixed; right: 22px; top: 96px; bottom: 96px; width: 236px; z-index: 9;
   display: flex; flex-direction: column; align-items: stretch; gap: 12px; }
@@ -193,7 +200,7 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   border: 1px solid var(--line-2); border-radius: 3px; padding: 0 10px;
   font-family: var(--mono); font-size: 12px; }
 #findInput::placeholder { color: var(--faint); }
-#findInput:focus { outline: none; border-color: var(--seal); }
+#findInput:focus { border-color: var(--seal); }
 #findInput::-webkit-search-cancel-button { -webkit-appearance: none; }
 #findHits { position: absolute; top: calc(100% + 5px); left: 0; right: 0; z-index: 12;
   max-height: 46vh; overflow-y: auto; background: var(--panel);
@@ -204,25 +211,25 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 #findHits .hit:hover, #findHits .hit.on { background: var(--ctl-bg); }
 #findHits .hn { font-family: var(--serif); font-size: 13px; color: var(--fg); line-height: 1.3;
   display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-#findHits .hm { font-family: var(--mono); font-size: 9.5px; color: var(--faint);
+#findHits .hm { font-family: var(--mono); font-size: 9.5px; color: var(--dim);
   letter-spacing: .06em; text-transform: uppercase; margin-top: 4px; display: block; }
-#findHits .none { padding: 9px 11px; font-family: var(--mono); font-size: 11px; color: var(--faint); }
+#findHits .none { padding: 9px 11px; font-family: var(--mono); font-size: 11px; color: var(--dim); }
 
 /* the colour key doubles as the project menu — click a row to narrow the galaxy */
 #projects { flex: 1 1 auto; min-height: 0; overflow-y: auto; text-align: right;
   scrollbar-width: thin; scrollbar-color: var(--line-2) transparent; }
 #projects::-webkit-scrollbar { width: 8px; }
 #projects::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 4px; }
-#projects .pr { display: flex; align-items: center; justify-content: flex-end; gap: 9px;
-  padding: 4px 2px 4px 8px; border-radius: 3px; cursor: pointer; font-family: var(--mono);
-  font-size: 10.5px; letter-spacing: .03em; color: var(--dim); line-height: 1.5;
-  transition: color .12s, background .12s; }
+#projects .pr { display: flex; align-items: center; justify-content: flex-end; gap: 9px; width: 100%;
+  padding: 4px 2px 4px 8px; border: 0; background: 0; border-radius: 3px; cursor: pointer;
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: .03em; color: var(--dim);
+  line-height: 1.5; text-align: right; transition: color .12s, background .12s; }
 #projects .pr:hover { color: var(--fg); background: var(--panel-2); }
 #projects .pr.on { color: var(--fg); }
 #projects .pr.on .nm::after { content: ""; position: absolute; right: -8px; top: 50%;
   width: 3px; height: 3px; margin-top: -1.5px; border-radius: 50%; background: var(--seal); }
 #projects .nm { position: relative; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-#projects .ct { color: var(--faint); font-variant-numeric: tabular-nums; flex: none; }
+#projects .ct { color: var(--fg-2); font-variant-numeric: tabular-nums; flex: none; }
 #projects .sw { width: 8px; height: 8px; border-radius: 50%; flex: none; }
 #projects .all { border-bottom: 1px solid var(--line); margin-bottom: 5px; padding-bottom: 7px; }
 
@@ -291,7 +298,7 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   background: var(--acc); border-radius: 4px 0 0 4px; }
 .step .pad { padding: 22px 30px 20px; }
 .step .meta { display: flex; align-items: center; gap: 9px; font-family: var(--mono); font-size: 10px;
-  letter-spacing: .13em; text-transform: uppercase; color: var(--faint); cursor: grab; }
+  letter-spacing: .13em; text-transform: uppercase; color: var(--dim); }
 .step .num { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; color: var(--seal);
   font-weight: 500; flex: none; }
 .step .meta .t { color: var(--acc); font-weight: 500; }
@@ -301,27 +308,30 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .step .body p { margin: 0 0 11px; }
 .step .body p:last-child { margin-bottom: 0; }
 .step .foot { display: flex; align-items: center; gap: 14px; margin-top: 16px; padding-top: 13px;
-  border-top: 1px solid var(--line); font-family: var(--mono); font-size: 10.5px; color: var(--faint); }
+  border-top: 1px solid var(--line); font-family: var(--mono); font-size: 10.5px; color: var(--fg-2); }
 .step .foot .when b { color: var(--gold); font-weight: 400; }
 /* a node on a side line of inquiry — same anatomy, quieter voice */
 .step.aside { width: 470px; background: var(--ctl-bg); }
 .step.aside h2 { font-size: 20px; }
 .step.aside .body { font-size: 14px; }
-.step.aside .num { color: var(--faint); }
+.step.aside .num { color: var(--dim); }
 .more { border: 0; background: 0; padding: 0; cursor: pointer; font-family: var(--mono);
   font-size: 10.5px; color: var(--gold); letter-spacing: .02em; }
 .more:hover { text-decoration: underline; text-underline-offset: 3px; }
 
 /* satellites, and the ground several lines rest on */
 .sat { position: absolute; width: 290px; background: var(--ctl-bg); border: 1px solid var(--line);
-  border-radius: 4px; padding: 13px 15px; cursor: pointer;
-  transition: transform .15s, border-color .15s; }
+  border-radius: 4px; padding: 13px 15px; cursor: pointer; display: block; text-align: left;
+  font: inherit; color: inherit; transition: transform .15s, border-color .15s; }
 .sat:hover { transform: translateY(-2px); border-color: var(--line-2); }
-.sat .rel { font-family: var(--mono); font-size: 9px; letter-spacing: .15em; text-transform: uppercase;
-  color: var(--acc); margin-bottom: 7px; }
-.sat h3 { margin: 0; font-weight: 500; font-size: 15px; line-height: 1.34; }
-.sat .ex { margin: 7px 0 0; font-size: 13px; line-height: 1.55; color: var(--dim); }
-.sat .tag { margin-top: 9px; font-family: var(--mono); font-size: 9.5px; color: var(--faint); letter-spacing: .04em; }
+.sat .rel { display: block; font-family: var(--mono); font-size: 9px; letter-spacing: .15em;
+  text-transform: uppercase; color: var(--acc); margin-bottom: 7px; }
+.sat .h3 { display: block; font-family: var(--serif); font-weight: 500; font-size: 15px;
+  line-height: 1.34; color: var(--fg); }
+.sat .ex { display: block; margin-top: 7px; font-family: var(--serif); font-size: 13px;
+  line-height: 1.55; color: var(--dim); }
+.sat .tag { display: block; margin-top: 9px; font-family: var(--mono); font-size: 9.5px;
+  color: var(--dim); letter-spacing: .04em; }
 .sat.bed { background: var(--bg); border-color: var(--line-2); }
 .sat.bed .rel { color: var(--gold); }
 .bedlabel { position: absolute; width: 640px; white-space: nowrap; font-family: var(--mono);
@@ -329,7 +339,7 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .lanetag { position: absolute; white-space: nowrap; font-family: var(--mono); font-size: 10px;
   letter-spacing: .1em; text-transform: uppercase; color: var(--dim); line-height: 1;
   display: flex; align-items: baseline; gap: 9px; }
-.lanetag .ln { font-size: 19px; letter-spacing: 0; color: var(--faint); font-weight: 500; }
+.lanetag .ln { font-size: 19px; letter-spacing: 0; color: var(--dim); font-weight: 500; }
 .lanetag.main { color: var(--fg-2); }
 .lanetag.main .ln { color: var(--seal); }
 
@@ -370,3 +380,11 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   border: 1px solid var(--line); border-radius: 2px; padding: 0 4px; }
 /* the way into the reader from a node you clicked in the galaxy */
 #readout .rd { margin-top: 13px; width: 100%; justify-content: center; }
+
+/* ── motion, only for those who want it ────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important; animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important; scroll-behavior: auto !important;
+  }
+}

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -279,6 +279,7 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   align-items: center; gap: 18px; padding: 14px 22px;
   background: color-mix(in srgb, var(--panel) 92%, transparent);
   border-bottom: 1px solid var(--line); backdrop-filter: blur(8px); }
+#rbar #rPrev { border-color: var(--seal); color: var(--seal-fg); }
 #rbar .rtitle { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 #rbar .rkind { font-family: var(--mono); font-size: 9px; letter-spacing: .2em;
   text-transform: uppercase; color: var(--seal); }

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -182,6 +182,8 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 #readout .ts { margin-top: 11px; font-family: var(--mono); font-size: 10px; color: var(--faint);
   letter-spacing: .04em; }
 #readout .ts b { color: var(--gold); font-weight: 400; }
+/* the way into the reader from a node you clicked in the galaxy */
+#readout .rd { margin-top: 14px; width: 100%; justify-content: center; }
 
 /* ── legend ───────────────────────────────────────────── */
 /* keyboard focus is visible everywhere; pointer users still see nothing */

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -163,7 +163,7 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   color: var(--fg); box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28); }
 
 /* ── readout (node card) ──────────────────────────────── */
-#readout { position: fixed; top: 96px; right: 22px; width: 320px; max-width: 38vw; z-index: 9;
+#readout { position: fixed; top: 96px; right: 270px; width: 320px; max-width: 32vw; z-index: 9;
   background: var(--panel); border: 1px solid var(--line-2); border-radius: 5px; display: none; }
 #readout.show { display: block; }
 #readout .bar { height: 3px; background: var(--gold); border-radius: 5px 5px 0 0; }
@@ -184,11 +184,54 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 #readout .ts b { color: var(--gold); font-weight: 400; }
 
 /* ── legend ───────────────────────────────────────────── */
-#legend { position: fixed; bottom: 150px; right: 22px; z-index: 9; font-family: var(--mono);
-  font-size: 10.5px; color: var(--dim); text-align: right; line-height: 1.85;
-  letter-spacing: .03em; pointer-events: none; }
+/* ── right rail: find a node, or narrow to one project ─── */
+#rail { position: fixed; right: 22px; top: 96px; bottom: 96px; width: 236px; z-index: 9;
+  display: flex; flex-direction: column; align-items: stretch; gap: 12px; }
+
+#find { flex: none; position: relative; }
+#findInput { width: 100%; height: 30px; background: var(--ctl-bg); color: var(--fg);
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 0 10px;
+  font-family: var(--mono); font-size: 12px; }
+#findInput::placeholder { color: var(--faint); }
+#findInput:focus { outline: none; border-color: var(--seal); }
+#findInput::-webkit-search-cancel-button { -webkit-appearance: none; }
+#findHits { position: absolute; top: calc(100% + 5px); left: 0; right: 0; z-index: 12;
+  max-height: 46vh; overflow-y: auto; background: var(--panel);
+  border: 1px solid var(--line-2); border-radius: 3px;
+  scrollbar-width: thin; scrollbar-color: var(--line-2) transparent; }
+#findHits .hit { padding: 8px 11px; border-top: 1px solid var(--line); cursor: pointer; }
+#findHits .hit:first-child { border-top: 0; }
+#findHits .hit:hover, #findHits .hit.on { background: var(--ctl-bg); }
+#findHits .hn { font-family: var(--serif); font-size: 13px; color: var(--fg); line-height: 1.3;
+  display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#findHits .hm { font-family: var(--mono); font-size: 9.5px; color: var(--faint);
+  letter-spacing: .06em; text-transform: uppercase; margin-top: 4px; display: block; }
+#findHits .none { padding: 9px 11px; font-family: var(--mono); font-size: 11px; color: var(--faint); }
+
+/* the colour key doubles as the project menu — click a row to narrow the galaxy */
+#projects { flex: 1 1 auto; min-height: 0; overflow-y: auto; text-align: right;
+  scrollbar-width: thin; scrollbar-color: var(--line-2) transparent; }
+#projects::-webkit-scrollbar { width: 8px; }
+#projects::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 4px; }
+#projects .pr { display: flex; align-items: center; justify-content: flex-end; gap: 9px;
+  padding: 4px 2px 4px 8px; border-radius: 3px; cursor: pointer; font-family: var(--mono);
+  font-size: 10.5px; letter-spacing: .03em; color: var(--dim); line-height: 1.5;
+  transition: color .12s, background .12s; }
+#projects .pr:hover { color: var(--fg); background: var(--panel-2); }
+#projects .pr.on { color: var(--fg); }
+#projects .pr.on .nm::after { content: ""; position: absolute; right: -8px; top: 50%;
+  width: 3px; height: 3px; margin-top: -1.5px; border-radius: 50%; background: var(--seal); }
+#projects .nm { position: relative; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#projects .ct { color: var(--faint); font-variant-numeric: tabular-nums; flex: none; }
+#projects .sw { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+#projects .all { border-bottom: 1px solid var(--line); margin-bottom: 5px; padding-bottom: 7px; }
+
+#legend { flex: none; font-family: var(--mono); font-size: 10.5px; color: var(--dim);
+  text-align: right; line-height: 1.85; letter-spacing: .03em; pointer-events: none;
+  padding-top: 9px; border-top: 1px solid var(--line); }
 #legend .sw { display: inline-block; width: 8px; height: 8px; border-radius: 50%;
   margin-left: 9px; vertical-align: 1px; }
+#legend:empty { display: none; }
 
 /* ── guided-tour card ─────────────────────────────────── */
 #script { position: fixed; left: 0; right: 0; bottom: 26px; z-index: 20;

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -209,3 +209,121 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .dots { display: inline-flex; gap: 7px; }
 .dots .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--line-2); }
 .dots .dot.on { background: var(--seal); }
+
+/* ── reader ───────────────────────────────────────────── */
+/* The galaxy answers WHERE a thought sits; the reader answers WHAT it says.
+   No palette of its own — it borrows the existing pair. A sheet lies ON a
+   desk, so the FIELD is the darker --panel and a CARD is the lighter --bg
+   (--panel is darker than --bg in both themes, so the relation holds either
+   way); a quieter card sits between them on --ctl-bg. The reader therefore
+   inherits future moves of the brand palette instead of drifting from them. */
+#reader { position: fixed; inset: 0; z-index: 8; background: var(--panel); }
+#rcanvas { position: absolute; inset: 0; cursor: grab; overflow: hidden;
+  background-image: radial-gradient(var(--line-2) 1.1px, transparent 1.2px);
+  background-size: 28px 28px; }
+#rcanvas.grabbing { cursor: grabbing; }
+#rworld { position: absolute; top: 0; left: 0; transform-origin: 0 0; will-change: transform; }
+#rtrack { position: absolute; top: 0; left: 0; overflow: visible; pointer-events: none; }
+#rhint { position: absolute; bottom: 96px; left: 24px; z-index: 9; font-family: var(--mono);
+  font-size: 10.5px; letter-spacing: .04em; color: var(--dim); pointer-events: none; }
+#rzoom { font-variant-numeric: tabular-nums; }
+
+/* the trail's title page */
+.thesis { position: absolute; width: 452px; background: var(--bg);
+  border: 1px solid var(--line-2); border-radius: 4px; padding: 30px 34px 26px; }
+.thesis::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+  background: var(--seal); border-radius: 4px 0 0 4px; }
+.thesis .kind { font-family: var(--mono); font-size: 10px; letter-spacing: .2em;
+  text-transform: uppercase; color: var(--seal); margin-bottom: 12px; }
+.thesis h1 { margin: 0 0 14px; font-weight: 600; font-size: 32px; line-height: 1.14; letter-spacing: -.015em; }
+.thesis .lede { margin: 0; font-size: 15.5px; line-height: 1.62; color: var(--fg-2); }
+.thesis .meta { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--line);
+  font-family: var(--mono); font-size: 11px; color: var(--dim); line-height: 1.9; }
+.thesis .meta b { color: var(--fg-2); font-weight: 400; }
+
+/* a step on the trail */
+.step { position: absolute; width: 540px; background: var(--bg);
+  border: 1px solid var(--line-2); border-radius: 4px; cursor: default; }
+.step::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+  background: var(--acc); border-radius: 4px 0 0 4px; }
+.step .pad { padding: 22px 30px 20px; }
+.step .meta { display: flex; align-items: center; gap: 9px; font-family: var(--mono); font-size: 10px;
+  letter-spacing: .13em; text-transform: uppercase; color: var(--faint); cursor: grab; }
+.step .num { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; color: var(--seal);
+  font-weight: 500; flex: none; }
+.step .meta .t { color: var(--acc); font-weight: 500; }
+.step .meta .s { opacity: .45; }
+.step h2 { margin: 11px 0 0; font-weight: 500; font-size: 23px; line-height: 1.24; letter-spacing: -.01em; }
+.step .body { margin-top: 12px; font-size: 15px; line-height: 1.7; color: var(--fg-2); }
+.step .body p { margin: 0 0 11px; }
+.step .body p:last-child { margin-bottom: 0; }
+.step .foot { display: flex; align-items: center; gap: 14px; margin-top: 16px; padding-top: 13px;
+  border-top: 1px solid var(--line); font-family: var(--mono); font-size: 10.5px; color: var(--faint); }
+.step .foot .when b { color: var(--gold); font-weight: 400; }
+/* a node on a side line of inquiry — same anatomy, quieter voice */
+.step.aside { width: 470px; background: var(--ctl-bg); }
+.step.aside h2 { font-size: 20px; }
+.step.aside .body { font-size: 14px; }
+.step.aside .num { color: var(--faint); }
+.more { border: 0; background: 0; padding: 0; cursor: pointer; font-family: var(--mono);
+  font-size: 10.5px; color: var(--gold); letter-spacing: .02em; }
+.more:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+/* satellites, and the ground several lines rest on */
+.sat { position: absolute; width: 290px; background: var(--ctl-bg); border: 1px solid var(--line);
+  border-radius: 4px; padding: 13px 15px; cursor: pointer;
+  transition: transform .15s, border-color .15s; }
+.sat:hover { transform: translateY(-2px); border-color: var(--line-2); }
+.sat .rel { font-family: var(--mono); font-size: 9px; letter-spacing: .15em; text-transform: uppercase;
+  color: var(--acc); margin-bottom: 7px; }
+.sat h3 { margin: 0; font-weight: 500; font-size: 15px; line-height: 1.34; }
+.sat .ex { margin: 7px 0 0; font-size: 13px; line-height: 1.55; color: var(--dim); }
+.sat .tag { margin-top: 9px; font-family: var(--mono); font-size: 9.5px; color: var(--faint); letter-spacing: .04em; }
+.sat.bed { background: var(--bg); border-color: var(--line-2); }
+.sat.bed .rel { color: var(--gold); }
+.bedlabel { position: absolute; width: 640px; white-space: nowrap; font-family: var(--mono);
+  font-size: 10px; letter-spacing: .16em; text-transform: uppercase; color: var(--dim); }
+.lanetag { position: absolute; white-space: nowrap; font-family: var(--mono); font-size: 10px;
+  letter-spacing: .1em; text-transform: uppercase; color: var(--dim); line-height: 1;
+  display: flex; align-items: baseline; gap: 9px; }
+.lanetag .ln { font-size: 19px; letter-spacing: 0; color: var(--faint); font-weight: 500; }
+.lanetag.main { color: var(--fg-2); }
+.lanetag.main .ln { color: var(--seal); }
+
+/* manuscript — the same trail as one continuous read, on a sheet */
+#manuscript { position: absolute; inset: 0; overflow-y: auto; display: none; background: var(--panel); }
+#manuscript.on { display: block; }
+.ms { max-width: 1080px; margin: 44px auto 150px; padding: 78px 72px 110px; display: grid;
+  grid-template-columns: 1fr 250px; gap: 0 42px; background: var(--bg);
+  border: 1px solid var(--line-2); border-radius: 4px; }
+.ms > * { grid-column: 1; }
+.ms .kind { font-family: var(--mono); font-size: 10px; letter-spacing: .2em;
+  text-transform: uppercase; color: var(--seal); }
+.ms h1 { margin: 14px 0 0; font-weight: 600; font-size: 44px; line-height: 1.1;
+  letter-spacing: -.02em; max-width: 20ch; }
+.ms .lede { margin: 20px 0 0; font-size: 19px; line-height: 1.6; color: var(--fg-2);
+  max-width: 62ch; font-style: italic; }
+.ms .byline { margin: 26px 0 0; padding-bottom: 30px; border-bottom: 1px solid var(--line-2);
+  font-family: var(--mono); font-size: 11px; color: var(--dim); letter-spacing: .04em; }
+.ms section { margin-top: 44px; }
+.ms .snum { font-family: var(--mono); font-size: 11px; letter-spacing: .18em; color: var(--acc); }
+.ms h2 { margin: 10px 0 0; font-weight: 500; font-size: 27px; line-height: 1.24;
+  letter-spacing: -.012em; max-width: 26ch; }
+.ms .prose { margin-top: 14px; font-size: 16.5px; line-height: 1.75; color: var(--fg-2); max-width: 64ch; }
+.ms .prose p { margin: 0 0 14px; }
+.ms .when { margin-top: 6px; font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+.ms .when b { color: var(--gold); font-weight: 400; }
+.marg { grid-column: 2; align-self: start; margin-top: 52px; padding-left: 18px;
+  border-left: 1px solid var(--line-2); }
+.marg .mtitle { font-family: var(--mono); font-size: 9px; letter-spacing: .15em;
+  text-transform: uppercase; color: var(--dim); margin-bottom: 10px; }
+.marg a { display: block; margin-bottom: 12px; text-decoration: none; color: var(--fg-2); cursor: pointer; }
+.marg a:hover { color: var(--fg); }
+.marg .r { font-family: var(--mono); font-size: 9px; letter-spacing: .08em; color: var(--acc); display: block; }
+.marg .n { font-size: 13.5px; line-height: 1.4; }
+
+.rmark { background: color-mix(in srgb, var(--gold) 22%, transparent); border-radius: 2px; padding: 0 3px; }
+#reader code { font-family: var(--mono); font-size: .88em; background: var(--ctl-bg);
+  border: 1px solid var(--line); border-radius: 2px; padding: 0 4px; }
+/* the way into the reader from a node you clicked in the galaxy */
+#readout .rd { margin-top: 13px; width: 100%; justify-content: center; }

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -261,12 +261,11 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .dots .dot.on { background: var(--seal); }
 
 /* ── reader ───────────────────────────────────────────── */
-/* The galaxy answers WHERE a thought sits; the reader answers WHAT it says.
-   No palette of its own — it borrows the existing pair. A sheet lies ON a
-   desk, so the FIELD is the darker --panel and a CARD is the lighter --bg
-   (--panel is darker than --bg in both themes, so the relation holds either
-   way); a quieter card sits between them on --ctl-bg. The reader therefore
-   inherits future moves of the brand palette instead of drifting from them. */
+/* Two views, two jobs. The MAP shows the shape of the reasoning — compact
+   steps you can take in at a glance, forks visible. READ is where the words
+   are. The map used to render every body in full, which put eight essays on
+   one canvas and made the shape impossible to see.
+   No palette of its own: field is the darker --panel, a card the lighter --bg. */
 #reader { position: fixed; inset: 0; z-index: 8; background: var(--panel); }
 #rcanvas { position: absolute; inset: 0; cursor: grab; overflow: hidden;
   background-image: radial-gradient(var(--line-2) 1.1px, transparent 1.2px);
@@ -274,114 +273,89 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 #rcanvas.grabbing { cursor: grabbing; }
 #rworld { position: absolute; top: 0; left: 0; transform-origin: 0 0; will-change: transform; }
 #rtrack { position: absolute; top: 0; left: 0; overflow: visible; pointer-events: none; }
-#rhint { position: absolute; bottom: 96px; left: 24px; z-index: 9; font-family: var(--mono);
+
+/* the reader's own bar — it borrows nothing from the galaxy console */
+#rbar { position: absolute; top: 0; left: 0; right: 0; z-index: 12; display: flex;
+  align-items: center; gap: 18px; padding: 14px 22px;
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
+  border-bottom: 1px solid var(--line); backdrop-filter: blur(8px); }
+#rbar .rtitle { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+#rbar .rkind { font-family: var(--mono); font-size: 9px; letter-spacing: .2em;
+  text-transform: uppercase; color: var(--seal); }
+#rbar .rtitle b { font-family: var(--serif); font-weight: 500; font-size: 17px;
+  letter-spacing: -.01em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#rbar #rView { margin-left: auto; }
+#rhint { position: absolute; bottom: 22px; left: 24px; z-index: 9; font-family: var(--mono);
   font-size: 10.5px; letter-spacing: .04em; color: var(--dim); pointer-events: none; }
-#rzoom { font-variant-numeric: tabular-nums; }
 
-/* the trail's title page */
-.thesis { position: absolute; width: 452px; background: var(--bg);
-  border: 1px solid var(--line-2); border-radius: 4px; padding: 30px 34px 26px; }
-.thesis::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
-  background: var(--seal); border-radius: 4px 0 0 4px; }
-.thesis .kind { font-family: var(--mono); font-size: 10px; letter-spacing: .2em;
-  text-transform: uppercase; color: var(--seal); margin-bottom: 12px; }
-.thesis h1 { margin: 0 0 14px; font-weight: 600; font-size: 32px; line-height: 1.14; letter-spacing: -.015em; }
-.thesis .lede { margin: 0; font-size: 15.5px; line-height: 1.62; color: var(--fg-2); }
-.thesis .meta { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--line);
-  font-family: var(--mono); font-size: 11px; color: var(--dim); line-height: 1.9; }
-.thesis .meta b { color: var(--fg-2); font-weight: 400; }
-
-/* a step on the trail */
-.step { position: absolute; width: 540px; background: var(--bg);
-  border: 1px solid var(--line-2); border-radius: 4px; cursor: default; }
+/* ── map: a step is a station, not a page ─────────────── */
+.step { position: absolute; width: 330px; background: var(--bg); border: 1px solid var(--line-2);
+  border-radius: 4px; padding: 15px 18px 14px; cursor: pointer; display: block; text-align: left;
+  font: inherit; color: inherit; transition: border-color .15s, transform .15s; }
 .step::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
   background: var(--acc); border-radius: 4px 0 0 4px; }
-.step .pad { padding: 22px 30px 20px; }
-.step .meta { display: flex; align-items: center; gap: 9px; font-family: var(--mono); font-size: 10px;
-  letter-spacing: .13em; text-transform: uppercase; color: var(--dim); }
-.step .num { font-family: var(--mono); font-size: 11px; letter-spacing: .06em; color: var(--seal);
-  font-weight: 500; flex: none; }
+.step:hover { border-color: var(--acc); transform: translateY(-2px); }
+.step .meta { display: flex; align-items: center; gap: 8px; font-family: var(--mono);
+  font-size: 9.5px; letter-spacing: .13em; text-transform: uppercase; color: var(--dim); }
+.step .num { font-family: var(--mono); font-size: 10px; color: var(--seal); font-weight: 500; flex: none; }
 .step .meta .t { color: var(--acc); font-weight: 500; }
-.step .meta .s { opacity: .45; }
-.step h2 { margin: 11px 0 0; font-weight: 500; font-size: 23px; line-height: 1.24; letter-spacing: -.01em; }
-/* Enough to read at a glance, capped so one long node cannot dominate the
-   trail; `expand` lifts the cap. */
-.step .body { position: relative; margin-top: 12px; font-size: 15px; line-height: 1.7;
-  color: var(--fg-2); max-height: 320px; overflow: hidden; }
-.step .body.clipped::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0;
-  height: 64px; background: linear-gradient(to bottom, transparent, var(--bg)); }
-/* Expanding must not blow up the trail: the card grows to a bounded height and
-   the rest of the body scrolls inside it, so lanes keep their spacing. */
-.step.open .body { max-height: min(62vh, 780px); overflow-y: auto; overscroll-behavior: contain;
-  scrollbar-width: thin; scrollbar-color: var(--line-2) transparent; }
-.step.open .body::-webkit-scrollbar { width: 8px; }
-.step.open .body::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 4px; }
-.step.open .body.clipped::after { content: none; }
-.step.aside.open .body, .step.aside .body { }
-.step .body p { margin: 0 0 11px; }
-.step .body p:last-child { margin-bottom: 0; }
-.step .foot { display: flex; align-items: center; gap: 14px; margin-top: 16px; padding-top: 13px;
-  border-top: 1px solid var(--line); font-family: var(--mono); font-size: 10.5px; color: var(--fg-2); }
-.step .foot .when b { color: var(--gold); font-weight: 400; }
-/* a node on a side line of inquiry — same anatomy, quieter voice */
-.step.aside { width: 470px; background: var(--ctl-bg); }
-.step.aside h2 { font-size: 20px; }
-.step.aside .body { font-size: 14px; }
-.step.aside .num { color: var(--dim); }
-.more { border: 0; background: 0; padding: 0; cursor: pointer; font-family: var(--mono);
-  font-size: 10.5px; color: var(--gold); letter-spacing: .02em; }
-.more:hover { text-decoration: underline; text-underline-offset: 3px; }
+.step .meta .s { opacity: .4; }
+.step h2 { margin: 9px 0 0; font-family: var(--serif); font-weight: 500; font-size: 17px;
+  line-height: 1.28; letter-spacing: -.01em; color: var(--fg); }
+.step .gist { margin: 7px 0 0; font-family: var(--serif); font-size: 13px; line-height: 1.5;
+  color: var(--dim); display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden; }
+.step .when { display: block; margin-top: 10px; font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-2); letter-spacing: .03em; }
+/* a step off the authored chain is quieter but the same shape */
+.step.aside { width: 300px; background: var(--ctl-bg); }
+.step.aside h2 { font-size: 15.5px; }
 
-/* satellites, and the ground several lines rest on */
-.sat { position: absolute; width: 290px; background: var(--ctl-bg); border: 1px solid var(--line);
-  border-radius: 4px; padding: 13px 15px; cursor: pointer; display: block; text-align: left;
-  font: inherit; color: inherit; transition: transform .15s, border-color .15s; }
-.sat:hover { transform: translateY(-2px); border-color: var(--line-2); }
-.sat .rel { display: block; font-family: var(--mono); font-size: 9px; letter-spacing: .15em;
-  text-transform: uppercase; color: var(--acc); margin-bottom: 7px; }
-.sat .h3 { display: block; font-family: var(--serif); font-weight: 500; font-size: 15px;
-  line-height: 1.34; color: var(--fg); }
-.sat .ex { display: block; margin-top: 7px; font-family: var(--serif); font-size: 13px;
-  line-height: 1.55; color: var(--dim); }
-.sat .tag { display: block; margin-top: 9px; font-family: var(--mono); font-size: 9.5px;
-  color: var(--dim); letter-spacing: .04em; }
+/* what a step leans on, and what several of them share */
+.sat { position: absolute; width: 250px; background: var(--ctl-bg); border: 1px solid var(--line);
+  border-radius: 4px; padding: 11px 13px; cursor: pointer; display: block; text-align: left;
+  font: inherit; color: inherit; transition: border-color .15s, transform .15s; }
+.sat:hover { border-color: var(--acc); transform: translateY(-2px); }
+.sat .rel { display: block; font-family: var(--mono); font-size: 8.5px; letter-spacing: .15em;
+  text-transform: uppercase; color: var(--acc); margin-bottom: 6px; }
+.sat .h3 { display: block; font-family: var(--serif); font-weight: 500; font-size: 13.5px;
+  line-height: 1.3; color: var(--fg); }
+.sat .ex, .sat .tag { display: none; }
 .sat.bed { background: var(--bg); border-color: var(--line-2); }
 .sat.bed .rel { color: var(--gold); }
 .bedlabel { position: absolute; width: 640px; white-space: nowrap; font-family: var(--mono);
   font-size: 10px; letter-spacing: .16em; text-transform: uppercase; color: var(--dim); }
-/* One line, one size — a big letter next to small caps sat on a different
-   baseline and read as broken. */
 .lanetag { position: absolute; white-space: nowrap; font-family: var(--mono); font-size: 10px;
-  letter-spacing: .14em; text-transform: uppercase; color: var(--dim); line-height: 18px;
-  height: 18px; }
+  letter-spacing: .14em; text-transform: uppercase; color: var(--dim); line-height: 18px; height: 18px; }
 .lanetag .ln { color: var(--dim); font-weight: 500; }
 .lanetag.main { color: var(--fg-2); }
 .lanetag.main .ln { color: var(--seal); }
 
-/* manuscript — the same trail as one continuous read, on a sheet */
+/* ── read: the trail as one continuous text, on a sheet ─ */
 #manuscript { position: absolute; inset: 0; overflow-y: auto; display: none; background: var(--panel); }
 #manuscript.on { display: block; }
-.ms { max-width: 1080px; margin: 44px auto 150px; padding: 78px 72px 110px; display: grid;
+.ms { max-width: 1080px; margin: 96px auto 90px; padding: 78px 72px 96px; display: grid;
   grid-template-columns: 1fr 250px; gap: 0 42px; background: var(--bg);
   border: 1px solid var(--line-2); border-radius: 4px; }
 .ms > * { grid-column: 1; }
 .ms .kind { font-family: var(--mono); font-size: 10px; letter-spacing: .2em;
   text-transform: uppercase; color: var(--seal); }
-.ms h1 { margin: 14px 0 0; font-weight: 600; font-size: 44px; line-height: 1.1;
+.ms h1 { margin: 14px 0 0; font-weight: 600; font-size: 42px; line-height: 1.1;
   letter-spacing: -.02em; max-width: 20ch; }
 .ms .lede { margin: 20px 0 0; font-size: 19px; line-height: 1.6; color: var(--fg-2);
   max-width: 62ch; font-style: italic; }
 .ms .byline { margin: 26px 0 0; padding-bottom: 30px; border-bottom: 1px solid var(--line-2);
   font-family: var(--mono); font-size: 11px; color: var(--dim); letter-spacing: .04em; }
-.ms section { margin-top: 44px; }
+.ms section { margin-top: 46px; scroll-margin-top: 96px; }
+.ms section.here .snum { color: var(--seal); }
 .ms .snum { font-family: var(--mono); font-size: 11px; letter-spacing: .18em; color: var(--acc); }
-.ms h2 { margin: 10px 0 0; font-weight: 500; font-size: 27px; line-height: 1.24;
+.ms h2 { margin: 10px 0 0; font-weight: 500; font-size: 26px; line-height: 1.24;
   letter-spacing: -.012em; max-width: 26ch; }
 .ms .prose { margin-top: 14px; font-size: 16.5px; line-height: 1.75; color: var(--fg-2); max-width: 64ch; }
 .ms .prose p { margin: 0 0 14px; }
-.ms .when { margin-top: 6px; font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+.ms .when { margin-top: 6px; font-family: var(--mono); font-size: 10.5px; color: var(--fg-2); }
 .ms .when b { color: var(--gold); font-weight: 400; }
-.marg { grid-column: 2; align-self: start; margin-top: 52px; padding-left: 18px;
+.marg { grid-column: 2; align-self: start; margin-top: 54px; padding-left: 18px;
   border-left: 1px solid var(--line-2); }
 .marg .mtitle { font-family: var(--mono); font-size: 9px; letter-spacing: .15em;
   text-transform: uppercase; color: var(--dim); margin-bottom: 10px; }
@@ -393,8 +367,6 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .rmark { background: color-mix(in srgb, var(--gold) 22%, transparent); border-radius: 2px; padding: 0 3px; }
 #reader code { font-family: var(--mono); font-size: .88em; background: var(--ctl-bg);
   border: 1px solid var(--line); border-radius: 2px; padding: 0 4px; }
-/* the way into the reader from a node you clicked in the galaxy */
-#readout .rd { margin-top: 13px; width: 100%; justify-content: center; }
 
 /* ── motion, only for those who want it ────────────────── */
 @media (prefers-reduced-motion: reduce) {

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -359,10 +359,13 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   border-left: 1px solid var(--line-2); }
 .marg .mtitle { font-family: var(--mono); font-size: 9px; letter-spacing: .15em;
   text-transform: uppercase; color: var(--dim); margin-bottom: 10px; }
-.marg a { display: block; margin-bottom: 12px; text-decoration: none; color: var(--fg-2); cursor: pointer; }
-.marg a:hover { color: var(--fg); }
-.marg .r { font-family: var(--mono); font-size: 9px; letter-spacing: .08em; color: var(--acc); display: block; }
-.marg .n { font-size: 13.5px; line-height: 1.4; }
+.marg .mlink { display: block; width: 100%; margin-bottom: 12px; padding: 0; border: 0;
+  background: 0; text-align: left; font: inherit; color: var(--fg-2); cursor: pointer; }
+.marg .mlink:hover { color: var(--fg); }
+.marg .mlink:hover .n { text-decoration: underline; text-underline-offset: 2px; }
+.marg .r { font-family: var(--mono); font-size: 9px; letter-spacing: .08em; color: var(--acc);
+  display: block; margin-bottom: 2px; }
+.marg .n { font-family: var(--serif); font-size: 13.5px; line-height: 1.4; display: block; }
 
 .rmark { background: color-mix(in srgb, var(--gold) 22%, transparent); border-radius: 2px; padding: 0 3px; }
 #reader code { font-family: var(--mono); font-size: .88em; background: var(--ctl-bg);

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -310,7 +310,12 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   color: var(--fg-2); max-height: 320px; overflow: hidden; }
 .step .body.clipped::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0;
   height: 64px; background: linear-gradient(to bottom, transparent, var(--bg)); }
-.step.open .body { max-height: none; overflow: visible; }
+/* Expanding must not blow up the trail: the card grows to a bounded height and
+   the rest of the body scrolls inside it, so lanes keep their spacing. */
+.step.open .body { max-height: min(62vh, 780px); overflow-y: auto; overscroll-behavior: contain;
+  scrollbar-width: thin; scrollbar-color: var(--line-2) transparent; }
+.step.open .body::-webkit-scrollbar { width: 8px; }
+.step.open .body::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 4px; }
 .step.open .body.clipped::after { content: none; }
 .step.aside.open .body, .step.aside .body { }
 .step .body p { margin: 0 0 11px; }
@@ -344,10 +349,12 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .sat.bed .rel { color: var(--gold); }
 .bedlabel { position: absolute; width: 640px; white-space: nowrap; font-family: var(--mono);
   font-size: 10px; letter-spacing: .16em; text-transform: uppercase; color: var(--dim); }
+/* One line, one size — a big letter next to small caps sat on a different
+   baseline and read as broken. */
 .lanetag { position: absolute; white-space: nowrap; font-family: var(--mono); font-size: 10px;
-  letter-spacing: .1em; text-transform: uppercase; color: var(--dim); line-height: 1;
-  display: flex; align-items: baseline; gap: 9px; }
-.lanetag .ln { font-size: 19px; letter-spacing: 0; color: var(--dim); font-weight: 500; }
+  letter-spacing: .14em; text-transform: uppercase; color: var(--dim); line-height: 18px;
+  height: 18px; }
+.lanetag .ln { color: var(--dim); font-weight: 500; }
 .lanetag.main { color: var(--fg-2); }
 .lanetag.main .ln { color: var(--seal); }
 

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -304,7 +304,15 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .step .meta .t { color: var(--acc); font-weight: 500; }
 .step .meta .s { opacity: .45; }
 .step h2 { margin: 11px 0 0; font-weight: 500; font-size: 23px; line-height: 1.24; letter-spacing: -.01em; }
-.step .body { margin-top: 12px; font-size: 15px; line-height: 1.7; color: var(--fg-2); }
+/* Enough to read at a glance, capped so one long node cannot dominate the
+   trail; `expand` lifts the cap. */
+.step .body { position: relative; margin-top: 12px; font-size: 15px; line-height: 1.7;
+  color: var(--fg-2); max-height: 320px; overflow: hidden; }
+.step .body.clipped::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0;
+  height: 64px; background: linear-gradient(to bottom, transparent, var(--bg)); }
+.step.open .body { max-height: none; overflow: visible; }
+.step.open .body.clipped::after { content: none; }
+.step.aside.open .body, .step.aside .body { }
 .step .body p { margin: 0 0 11px; }
 .step .body p:last-child { margin-bottom: 0; }
 .step .foot { display: flex; align-items: center; gap: 14px; margin-top: 16px; padding-top: 13px;


### PR DESCRIPTION
The galaxy answers *where* a thought sits. It cannot answer *what it says*: a
chain replay flashes excerpts past and a node's readout is a teaser. This adds
the second half — a reader over the same feed — plus the two things the galaxy
was missing to reach a node at all.

## The reader

Two views, two jobs.

**Map** shows the shape of the reasoning. A step is a station — number, kind,
title, two lines of gist, when it was asserted — so an eight-node research fits
on one screen and its forks are visible. The layout has a grammar: **X is how
far the reasoning was carried** (depth of derivation), **Y is which line of
inquiry**. A plain chain is a one-lane DAG, so linear trails and branching
deep-research share one layout instead of two implementations.

Lanes come from a path decomposition, so a lane is always a real parent→child
chain, and each rail runs only as far as its line actually goes. Slotting by
depth instead drops unrelated threads onto one rail and draws a continuity the
graph does not have. What several lines lean on is stated once as shared ground
beneath them rather than repeated under every step that cites it.

**Read** is where the words are. Clicking a station opens the text at that step
and marks it; side lines are carried too, so a branch can be read end to end.
Graph links sit in the margin, and every one of them leads somewhere. `← back`
appears once there is somewhere to return to and names it — Backspace and Alt+←
do the same.

Two ways in: `read` beside the chain picker, and `read this trail →` on any
node's readout. A node off every saved chain opens as itself plus whatever it
was derived from.

Reading is its own room: colour-by, focus, time-lapse, the node search and the
project list are instruments for surveying the galaxy, so the whole chrome
steps out while you read and the reader carries its own small bar.

## The rail

The colour key on the right became the menu: every project is a row — swatch,
name, node count — and clicking it focuses that cluster. And `find` reaches a
node by name instead of sweeping the galaxy with a cursor: picking a hit clears
whatever would hide it, flies the camera in and pins it, which lands you one
click from reading its trail. `/` focuses it, arrows walk the hits, Enter takes
one.

## Notes

No palette of its own. The reader borrows the existing pair: a sheet lies *on*
a desk, so the field is the darker `--panel` and a card the lighter `--bg`
(`--panel` is darker than `--bg` in both themes, so the relation holds either
way). It inherits future moves of the brand palette rather than drifting.

Bodies: the galaxy only needs excerpts, so the heavier `?bodies=true` feed is
fetched once, lazily, the first time the reader is opened.

An interface review over the whole surface turned up controls that looked
interactive and were not, text below AA, and no reduced-motion path; all of it
is in the history rather than left for later. Link cards and project rows are
buttons, the search is a real combobox that announces its result count, there
is one focus ring on `:focus-visible`, and motion is opt-in.

## Verification

`vite build` clean; dist bundles all 29 woff2 and the favicon; fonts.css
references match the files on disk exactly.

Walked end to end in both themes with no console errors: galaxy → pick a chain
→ map (8 nodes, 5 lines, zero overlaps between cards, satellites and lane tags)
→ open a step → read it → follow a margin link → step back → return to the
galaxy with its chrome restored. Layout was re-checked collapsed, with one card
expanded, with every card expanded, and folded back again.

**Not verified:** 200% zoom, a 320px viewport, and a real screen reader.
