### PR TITLE
feat(viz): the board — what the graph still owes

### DIFF
--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -88,7 +88,7 @@
           <select id="focus" class="ctl"><option value="">all projects</option></select>
         </div>
         <button id="boardBtn" class="btn">board</button>
-        <button id="talkBtn" class="btn">guided tour</button>
+        <button id="talkBtn" class="btn" aria-label="Guided tour">tour</button>
       </div>
       <div class="seg">
         <div class="field">

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -27,6 +27,24 @@
       <div id="rhint">click a step to read it</div>
     </section>
 
+    <!-- the board: the same tasks, owed instead of surveyed -->
+    <section id="board" hidden>
+      <header id="bbar">
+        <button id="bBack" class="btn">galaxy</button>
+        <div class="rtitle"><span class="rkind">task board</span><b>what is owed</b></div>
+        <div class="field bpick">
+          <label for="bInit">initiative</label>
+          <select id="bInit" class="ctl"></select>
+        </div>
+      </header>
+      <a class="skip" href="#bend">Skip the cards</a>
+      <div id="bcols"></div>
+      <span id="bend" tabindex="-1"></span>
+      <p id="bcount"></p>
+      <aside id="bdetail" aria-label="Card details" hidden></aside>
+      <p id="bsay" class="sr-only" role="status" aria-live="polite"></p>
+    </section>
+
     <header id="hud">
       <div class="seal" title="蛙 — kaeru, &quot;frog&quot;">蛙</div>
       <div class="wordmark">
@@ -62,6 +80,7 @@
           <label for="focus">focus</label>
           <select id="focus" class="ctl"><option value="">all projects</option></select>
         </div>
+        <button id="boardBtn" class="btn">board</button>
         <button id="talkBtn" class="btn">guided tour</button>
       </div>
       <div class="seg">

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -31,7 +31,7 @@
     <section id="board" hidden>
       <header id="bbar">
         <button id="bBack" class="btn">galaxy</button>
-        <div class="rtitle"><span class="rkind">task board</span><b>what is owed</b></div>
+        <div class="rtitle"><span class="rkind">task board</span><b id="bname">—</b></div>
         <div class="field bpick">
           <label for="bInit">initiative</label>
           <select id="bInit" class="ctl"></select>
@@ -41,7 +41,8 @@
       <div id="bcols"></div>
       <span id="bend" tabindex="-1"></span>
       <p id="bcount"></p>
-      <aside id="bdetail" aria-label="Card details" hidden></aside>
+      <!-- the card, over the board rather than squeezing it (Jira's drawer) -->
+      <aside id="bdetail" aria-labelledby="bdhead" hidden></aside>
       <p id="bsay" class="sr-only" role="status" aria-live="polite"></p>
     </section>
 

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -88,7 +88,7 @@
           <select id="focus" class="ctl"><option value="">all projects</option></select>
         </div>
         <button id="boardBtn" class="btn">board</button>
-        <button id="talkBtn" class="btn" aria-label="Guided tour">tour</button>
+        <button id="talkBtn" class="btn">guided tour</button>
       </div>
       <div class="seg">
         <div class="field">

--- a/kaeru-viz/index.html
+++ b/kaeru-viz/index.html
@@ -37,6 +37,12 @@
           <select id="bInit" class="ctl"></select>
         </div>
       </header>
+      <div id="bfilter">
+        <label class="sr-only" for="bFind">Filter cards by text</label>
+        <input id="bFind" type="search" placeholder="filter cards…" autocomplete="off" spellcheck="false" />
+        <div id="bsieves" role="group" aria-label="Quick filters"></div>
+        <button id="bClear" class="btn" hidden>clear</button>
+      </div>
       <a class="skip" href="#bend">Skip the cards</a>
       <div id="bcols"></div>
       <span id="bend" tabindex="-1"></span>

--- a/kaeru-viz/src/board.js
+++ b/kaeru-viz/src/board.js
@@ -105,45 +105,68 @@ export function createBoard(data, { onOpenNode }) {
     $('bcount').textContent = mine.length
       ? `${owed} owed${over ? `, ${over} past due` : ''} · sorted by rot — deadline, then age, then isolation`
       : ''
+    $('bname').textContent = init
     $('bsay').textContent = `${init}: ${owed} open, ${mine.length} cards total`
   }
 
-  // ── the detail strip ──────────────────────────────────────────────────────
-  // A read-only board still has to let you act. Rather than a copy button on
-  // every card — which would put 200+ controls in the tab order — the picked
-  // card opens one strip that holds the full text and the two commands.
+  // ── the card drawer ───────────────────────────────────────────────────────
+  // Over the board, never squeezing it — the same move Jira makes. One drawer
+  // rather than controls on every card: per-card buttons would have put 200+
+  // stops between the lanes and anything below them.
+  let returnFocusTo = null
   function drawDetail() {
     const c = CARDS.find((x) => x.id === picked)
     const strip = $('bdetail')
     strip.hidden = !c
     if (!c) return
+    const col = COLUMNS.find((x) => x.key === c.key)
     const from = c.island
       ? `<span class="isle">nothing links to this card yet</span>`
-      : `out of <b>${esc(deslug(N[c.src] ? N[c.src].name : ''))}</b>`
+      : `${esc(deslug(N[c.src] ? N[c.src].name : ''))}`
+    strip.tabIndex = -1
     strip.innerHTML = `
-      <div class="dtext">
+      <header id="bdhead">
+        <span class="k">card</span><span class="colname">${col ? col.label : c.key}</span>
+        <button type="button" class="btn x" data-close="1" aria-label="Close card">✕</button>
+      </header>
+      <div id="bdbody">
         <p class="dbody">${esc(c.text)}</p>
-        <p class="dmeta">${esc(c.init || '—')}<span class="sep">·</span>${c.age == null ? '—' : days(c.age)}
-          ${c.due ? `<span class="sep">·</span><span class="${c.overdue ? 'due' : 'soft'}">due ${esc(c.due)}</span>` : ''}
-          <span class="sep">·</span>${from}</p>
+        <dl>
+          <dt>initiative</dt><dd><span class="mono">${esc(c.init || '—')}</span></dd>
+          <dt>open for</dt><dd><span class="mono">${c.age == null ? '—' : days(c.age)}</span></dd>
+          ${c.due ? `<dt>due</dt><dd>${c.overdue
+            ? `<span class="due">${esc(c.due)} · past due</span>`
+            : `<span class="mono soft">${esc(c.due)}</span>`}</dd>` : ''}
+          <dt>came out of</dt><dd>${from}</dd>
+        </dl>
       </div>
-      <div class="dacts">
+      <div id="bdacts">
         <button type="button" class="btn" data-open="${esc(c.id)}">Open in reader</button>
         <button type="button" class="btn cp" data-copy="set_status ${esc(c.name)} in-progress">Copy “set_status”</button>
         <button type="button" class="btn cp" data-copy="done ${esc(c.name)}">Copy “done”</button>
-        <button type="button" class="btn" data-close="1" aria-label="Close card details">✕</button>
       </div>`
   }
+  function closeDetail() {
+    picked = null
+    drawColumns(); drawDetail()
+    if (returnFocusTo && document.contains(returnFocusTo)) returnFocusTo.focus()
+    returnFocusTo = null
+  }
 
-  function pick(id) { picked = picked === id ? null : id; drawColumns(); drawDetail() }
+  function pick(id, el) {
+    if (picked === id) { closeDetail(); return }
+    picked = id; returnFocusTo = el || null
+    drawColumns(); drawDetail()
+    $('bdetail').focus()
+  }
 
   // ── wiring ────────────────────────────────────────────────────────────────
   $('bcols').addEventListener('click', (e) => {
-    const b = e.target.closest('[data-card]'); if (b) pick(b.dataset.card)
+    const b = e.target.closest('[data-card]'); if (b) pick(b.dataset.card, b)
   })
   $('bdetail').addEventListener('click', (e) => {
     const b = e.target.closest('button'); if (!b) return
-    if (b.dataset.close) { picked = null; drawColumns(); drawDetail(); return }
+    if (b.dataset.close) { closeDetail(); return }
     if (b.dataset.open) { onOpenNode(b.dataset.open); return }
     if (!b.dataset.copy) return
     navigator.clipboard?.writeText(b.dataset.copy)
@@ -155,6 +178,14 @@ export function createBoard(data, { onOpenNode }) {
     $('bsay').textContent = `Copied: ${b.dataset.copy}`
     copyTimer = setTimeout(() => b.classList.remove('ok'), 1400)
   })
+  // Escape closes the drawer first; the room's own handler only gets it once
+  // there is no drawer left to close.
+  addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape' || $('board').hidden || !picked) return
+    e.stopImmediatePropagation(); e.preventDefault()
+    closeDetail()
+  })
+
   const pickInit = $('bInit')
   pickInit.innerHTML = OWNERS.map(([k, n]) => `<option value="${esc(k)}">${esc(k)} — ${n} open</option>`).join('')
   pickInit.addEventListener('change', () => { init = pickInit.value; picked = null; drawColumns(); drawDetail() })

--- a/kaeru-viz/src/board.js
+++ b/kaeru-viz/src/board.js
@@ -67,7 +67,8 @@ export function createBoard(data, { onOpenNode }) {
   const OWNERS = [...CARDS.reduce((m, c) => m.set(c.init, (m.get(c.init) || 0) + (c.key === 'done' ? 0 : 1)), new Map())]
     .filter(([k]) => k).sort((a, b) => b[1] - a[1])
 
-  let init = OWNERS.length ? OWNERS[0][0] : null
+  const ALL = '*'          // every initiative at once
+  let init = ALL
   let picked = null
   let copyTimer = null
 
@@ -85,11 +86,11 @@ export function createBoard(data, { onOpenNode }) {
     return `<button type="button" class="card${c.overdue ? ' overdue' : ''}${picked === c.id ? ' picked' : ''}"
         data-card="${esc(c.id)}" aria-pressed="${picked === c.id}">
       <span class="what">${esc(first(c.text))}</span>
-      <span class="meta"><span class="age">${c.age == null ? '—' : days(c.age)}</span>${flags ? `<span class="sep">·</span>${flags}` : ''}</span>
+      <span class="meta">${init === ALL && c.init ? `<span class="owner">${esc(c.init)}</span>` : ''}<span class="age">${c.age == null ? '—' : days(c.age)}</span>${flags ? `<span class="sep">·</span>${flags}` : ''}</span>
     </button>`
   }
   function drawColumns() {
-    const mine = CARDS.filter((c) => c.init === init)
+    const mine = init === ALL ? CARDS : CARDS.filter((c) => c.init === init)
     $('bcols').innerHTML = COLUMNS.map((col) => {
       const rows = mine.filter((c) => c.key === col.key)
         // rot orders what is still owed; a finished card is just newest-first
@@ -105,8 +106,8 @@ export function createBoard(data, { onOpenNode }) {
     $('bcount').textContent = mine.length
       ? `${owed} owed${over ? `, ${over} past due` : ''} · sorted by rot — deadline, then age, then isolation`
       : ''
-    $('bname').textContent = init
-    $('bsay').textContent = `${init}: ${owed} open, ${mine.length} cards total`
+    $('bname').textContent = init === ALL ? 'all initiatives' : init
+    $('bsay').textContent = `${init === ALL ? 'all initiatives' : init}: ${owed} open, ${mine.length} cards total`
   }
 
   // ── the card drawer ───────────────────────────────────────────────────────
@@ -122,7 +123,7 @@ export function createBoard(data, { onOpenNode }) {
     const col = COLUMNS.find((x) => x.key === c.key)
     const from = c.island
       ? `<span class="isle">nothing links to this card yet</span>`
-      : `${esc(deslug(N[c.src] ? N[c.src].name : ''))}`
+      : `<button type="button" class="nodelink" data-open="${esc(c.src)}">${esc(deslug(N[c.src] ? N[c.src].name : ''))}</button>`
     strip.tabIndex = -1
     strip.innerHTML = `
       <header id="bdhead">
@@ -132,11 +133,11 @@ export function createBoard(data, { onOpenNode }) {
       <div id="bdbody">
         <p class="dbody">${esc(c.text)}</p>
         <dl>
-          <dt>initiative</dt><dd><span class="mono">${esc(c.init || '—')}</span></dd>
-          <dt>open for</dt><dd><span class="mono">${c.age == null ? '—' : days(c.age)}</span></dd>
+          <dt>initiative</dt><dd>${esc(c.init || '—')}</dd>
+          <dt>open for</dt><dd>${c.age == null ? '—' : days(c.age)}</dd>
           ${c.due ? `<dt>due</dt><dd>${c.overdue
             ? `<span class="due">${esc(c.due)} · past due</span>`
-            : `<span class="mono soft">${esc(c.due)}</span>`}</dd>` : ''}
+            : `<span class="soft">${esc(c.due)}</span>`}</dd>` : ''}
           <dt>came out of</dt><dd>${from}</dd>
         </dl>
       </div>
@@ -187,13 +188,15 @@ export function createBoard(data, { onOpenNode }) {
   })
 
   const pickInit = $('bInit')
-  pickInit.innerHTML = OWNERS.map(([k, n]) => `<option value="${esc(k)}">${esc(k)} — ${n} open</option>`).join('')
+  const owedAll = CARDS.filter((c) => c.key !== 'done').length
+  pickInit.innerHTML = `<option value="${ALL}">all initiatives — ${owedAll} open</option>` +
+    OWNERS.map(([k, n]) => `<option value="${esc(k)}">${esc(k)} — ${n} open</option>`).join('')
   pickInit.addEventListener('change', () => { init = pickInit.value; picked = null; drawColumns(); drawDetail() })
 
   return {
     /** Open the board, optionally on a named initiative. */
     show(name) {
-      if (name && OWNERS.some(([k]) => k === name)) init = name
+      if (name === ALL || (name && OWNERS.some(([k]) => k === name))) init = name
       if (!init) return false
       pickInit.value = init
       picked = null

--- a/kaeru-viz/src/board.js
+++ b/kaeru-viz/src/board.js
@@ -54,11 +54,13 @@ export function createBoard(data, { onOpenNode }) {
     // than disappearing — same rule the `board` verb applies (board.md).
     const raw = (tagged(n, 'status:') || '').slice(7)
     const key = COLUMNS.some((c) => c.key === raw) ? raw : COLUMNS[0].key
+    const text = (n.body || '').trim() || deslug(n.name)
     return {
       id: n.id, name: n.name, key, age, due, overdue, src,
       island: near.length === 0,
       init: (n.initiatives || [])[0] || null,
-      text: (n.body || '').trim() || deslug(n.name),
+      text,
+      hay: (text + ' ' + deslug(n.name)).toLowerCase(),
       rot: (age || 0) + (near.length === 0 ? 45 : 0) + (overdue ? 400 : 0),
     }
   })
@@ -71,6 +73,56 @@ export function createBoard(data, { onOpenNode }) {
   let init = ALL
   let picked = null
   let copyTimer = null
+  // Filters stack: scope AND text AND every active sieve.
+  let query = ''
+  const sieveOn = new Set()
+
+  // `status:` and `due:` are the only tags a person sets, and both are already
+  // on the board as columns and badges. `topic:` is derived word-frequency —
+  // its busiest values here are "блок", "новый", "документ" — so a topic picker
+  // would mostly offer noise that free text finds better anyway.
+  const SIEVES = [
+    { key: 'overdue', label: 'past due', f: (c) => c.overdue },
+    { key: 'island', label: 'no provenance', f: (c) => c.island },
+    { key: 'old', label: 'over a month', f: (c) => c.age > 30 },
+    { key: 'owed', label: 'not done', f: (c) => c.key !== 'done' },
+  ]
+  const inScope = () => (init === ALL ? CARDS : CARDS.filter((c) => c.init === init))
+  const passes = (c) =>
+    (!query || c.hay.includes(query)) &&
+    [...sieveOn].every((k) => SIEVES.find((s) => s.key === k).f(c))
+  const filtering = () => !!(query || sieveOn.size)
+
+  // ── the filter bar ────────────────────────────────────────────────────────
+  // Built once and updated in place: rebuilding the controls on every
+  // keystroke would throw away focus mid-typing.
+  function buildSieves() {
+    $('bsieves').innerHTML = SIEVES.map((s) =>
+      `<button type="button" class="sieve" data-sieve="${s.key}" aria-pressed="false">
+         ${s.label} <span class="c"></span></button>`).join('')
+  }
+  function drawFilterBar(scoped) {
+    SIEVES.forEach((s) => {
+      const b = $('bsieves').querySelector(`[data-sieve="${s.key}"]`)
+      if (!b) return
+      const on = sieveOn.has(s.key)
+      b.setAttribute('aria-pressed', String(on))
+      b.classList.toggle('on', on)
+      b.querySelector('.c').textContent = scoped.filter(s.f).length
+    })
+    $('bClear').hidden = !filtering()
+  }
+  function describeFilters() {
+    const bits = []
+    if (query) bits.push(`“${query}”`)
+    sieveOn.forEach((k) => bits.push(SIEVES.find((s) => s.key === k).label))
+    return bits.join(' + ')
+  }
+  function clearFilters() {
+    query = ''; sieveOn.clear()
+    $('bFind').value = ''
+    drawColumns(); drawDetail()
+  }
 
   // ── the columns ───────────────────────────────────────────────────────────
   const first = (t) => {
@@ -90,7 +142,8 @@ export function createBoard(data, { onOpenNode }) {
     </button>`
   }
   function drawColumns() {
-    const mine = init === ALL ? CARDS : CARDS.filter((c) => c.init === init)
+    const scoped = inScope()
+    const mine = scoped.filter(passes)
     $('bcols').innerHTML = COLUMNS.map((col) => {
       const rows = mine.filter((c) => c.key === col.key)
         // rot orders what is still owed; a finished card is just newest-first
@@ -101,11 +154,17 @@ export function createBoard(data, { onOpenNode }) {
           : `<p class="none">${col.label} is empty.</p>`}</div>
       </section>`
     }).join('')
+    if (!mine.length && filtering()) {
+      $('bcols').innerHTML = `<p class="nohits">No cards match ${esc(describeFilters())}.
+        <button type="button" class="btn" id="bClear2">Clear filters</button></p>`
+    }
     const owed = mine.filter((c) => c.key !== 'done').length
     const over = mine.filter((c) => c.overdue && c.key !== 'done').length
+    const shown = filtering() ? `${mine.length} of ${scoped.length} cards · ` : ''
     $('bcount').textContent = mine.length
-      ? `${owed} owed${over ? `, ${over} past due` : ''} · sorted by rot — deadline, then age, then isolation`
+      ? `${shown}${owed} owed${over ? `, ${over} past due` : ''} · sorted by rot — deadline, then age, then isolation`
       : ''
+    drawFilterBar(scoped)
     $('bname').textContent = init === ALL ? 'all initiatives' : init
     $('bsay').textContent = `${init === ALL ? 'all initiatives' : init}: ${owed} open, ${mine.length} cards total`
   }
@@ -187,11 +246,34 @@ export function createBoard(data, { onOpenNode }) {
     closeDetail()
   })
 
+  $('bsieves').addEventListener('click', (e) => {
+    const b = e.target.closest('[data-sieve]'); if (!b) return
+    const k = b.dataset.sieve
+    if (sieveOn.has(k)) sieveOn.delete(k); else sieveOn.add(k)
+    drawColumns(); drawDetail()
+  })
+  $('bFind').addEventListener('input', (e) => {
+    query = e.target.value.trim().toLowerCase()
+    drawColumns(); drawDetail()
+  })
+  $('bFind').addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape' || !e.target.value) return
+    e.stopPropagation(); e.target.value = ''; query = ''; drawColumns(); drawDetail()
+  })
+  $('bClear').addEventListener('click', clearFilters)
+  $('bcols').addEventListener('click', (e) => {
+    if (e.target.id === 'bClear2') clearFilters()
+  })
+
   const pickInit = $('bInit')
+  buildSieves()
   const owedAll = CARDS.filter((c) => c.key !== 'done').length
-  pickInit.innerHTML = `<option value="${ALL}">all initiatives — ${owedAll} open</option>` +
-    OWNERS.map(([k, n]) => `<option value="${esc(k)}">${esc(k)} — ${n} open</option>`).join('')
-  pickInit.addEventListener('change', () => { init = pickInit.value; picked = null; drawColumns(); drawDetail() })
+  pickInit.innerHTML = `<option value="${ALL}">all initiatives (${owedAll} open)</option>` +
+    OWNERS.map(([k, n]) => `<option value="${esc(k)}">${esc(k)} (${n} open)</option>`).join('')
+  pickInit.addEventListener('change', () => {
+    init = pickInit.value; picked = null
+    drawColumns(); drawDetail()
+  })
 
   return {
     /** Open the board, optionally on a named initiative. */
@@ -199,6 +281,7 @@ export function createBoard(data, { onOpenNode }) {
       if (name === ALL || (name && OWNERS.some(([k]) => k === name))) init = name
       if (!init) return false
       pickInit.value = init
+      if (pickInit._sync) pickInit._sync()
       picked = null
       drawColumns(); drawDetail()
       // The cards read fine on excerpts; the detail strip is where the whole

--- a/kaeru-viz/src/board.js
+++ b/kaeru-viz/src/board.js
@@ -1,0 +1,181 @@
+// The board — the galaxy's third view.
+//
+// The galaxy answers *where* a thought sits, the reader *what it says*, and the
+// board *what is still owed*. It renders the task board `docs/board.md`
+// describes: one board per initiative, a card's column is the `status:<key>`
+// tag on the task itself, columns come from the initiative's registry.
+//
+// Read-only, deliberately. `/graph.json` carries the `status:*` tags but not
+// `properties`, so the column registry can't reach the browser yet and the
+// built-in vocabulary is what we render. Moving a card is `set_status`, a
+// write the viz endpoint doesn't have — so the board shows the command instead
+// of performing it.
+//
+// Within a column the order is *rot*, not recency: overdue first, then age,
+// then isolation. A task that has been open two months with nothing linked to
+// it is not "todo", it is the thing this room exists to surface.
+
+// The built-in vocabulary `write_task` stamps, in registry order (board.md).
+// Once the export carries `properties`, this is what the Board node replaces.
+import { loadFullBodies } from './bodies.js'
+
+const COLUMNS = [
+  { key: 'open', label: 'Open' },
+  { key: 'in-progress', label: 'In Progress' },
+  { key: 'done', label: 'Done' },
+]
+const DAY = 86400
+
+const $ = (id) => document.getElementById(id)
+const esc = (s) => (s || '').replace(/[&<>"']/g, (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[m]))
+const deslug = (s) => (s || '').replace(/-20\d\d-\d\d-\d\d$/, '').replace(/-[0-9a-f]{6}$/, '').replace(/-/g, ' ')
+const tagged = (n, p) => (n.tags || []).find((t) => t.startsWith(p))
+const days = (n) => (n === 1 ? '1 day' : `${n} days`)
+
+export function createBoard(data, { onOpenNode }) {
+  const N = {}, LINKS = {}
+  data.nodes.forEach((n) => { N[n.id] = n })
+  for (const e of data.edges) {
+    ;(LINKS[e.src] = LINKS[e.src] || []).push(e.dst)
+    ;(LINKS[e.dst] = LINKS[e.dst] || []).push(e.src)
+  }
+
+  const today = new Date().toISOString().slice(0, 10)
+  const now = Date.now() / 1000
+  // Every task, decorated with what the board needs to sort and explain it.
+  const CARDS = data.nodes.filter((n) => n.type === 'task').map((n) => {
+    const age = n.created_secs ? Math.floor((now - n.created_secs) / DAY) : null
+    const due = (tagged(n, 'due:') || '').slice(4) || null
+    const overdue = !!due && due < today
+    const near = (LINKS[n.id] || []).filter((id) => N[id])
+    // provenance: what the task fell out of — an episode when there is one
+    const src = near.find((id) => N[id].type === 'episode') || near[0] || null
+    // A status the registry doesn't know falls into the first column rather
+    // than disappearing — same rule the `board` verb applies (board.md).
+    const raw = (tagged(n, 'status:') || '').slice(7)
+    const key = COLUMNS.some((c) => c.key === raw) ? raw : COLUMNS[0].key
+    return {
+      id: n.id, name: n.name, key, age, due, overdue, src,
+      island: near.length === 0,
+      init: (n.initiatives || [])[0] || null,
+      text: (n.body || '').trim() || deslug(n.name),
+      rot: (age || 0) + (near.length === 0 ? 45 : 0) + (overdue ? 400 : 0),
+    }
+  })
+
+  // initiatives that actually own a task, busiest first
+  const OWNERS = [...CARDS.reduce((m, c) => m.set(c.init, (m.get(c.init) || 0) + (c.key === 'done' ? 0 : 1)), new Map())]
+    .filter(([k]) => k).sort((a, b) => b[1] - a[1])
+
+  let init = OWNERS.length ? OWNERS[0][0] : null
+  let picked = null
+  let copyTimer = null
+
+  // ── the columns ───────────────────────────────────────────────────────────
+  const first = (t) => {
+    const s = t.replace(/\s+/g, ' ').trim()
+    const cut = s.search(/[.!?](\s|$)/)
+    return cut > 24 && cut < 150 ? s.slice(0, cut + 1) : s
+  }
+  function card(c) {
+    const flags = [
+      c.overdue ? `<span class="due">due ${esc(c.due)}</span>` : c.due ? `<span class="soft">due ${esc(c.due)}</span>` : '',
+      c.island ? `<span class="isle">no provenance</span>` : '',
+    ].filter(Boolean).join('<span class="sep">·</span>')
+    return `<button type="button" class="card${c.overdue ? ' overdue' : ''}${picked === c.id ? ' picked' : ''}"
+        data-card="${esc(c.id)}" aria-pressed="${picked === c.id}">
+      <span class="what">${esc(first(c.text))}</span>
+      <span class="meta"><span class="age">${c.age == null ? '—' : days(c.age)}</span>${flags ? `<span class="sep">·</span>${flags}` : ''}</span>
+    </button>`
+  }
+  function drawColumns() {
+    const mine = CARDS.filter((c) => c.init === init)
+    $('bcols').innerHTML = COLUMNS.map((col) => {
+      const rows = mine.filter((c) => c.key === col.key)
+        // rot orders what is still owed; a finished card is just newest-first
+        .sort((a, b) => (col.key === 'done' ? (b.age == null) - (a.age == null) || a.age - b.age : b.rot - a.rot))
+      return `<section class="col" aria-labelledby="col-${col.key}">
+        <header class="colhead"><h2 id="col-${col.key}">${col.label}</h2><span class="n">${rows.length}</span></header>
+        <div class="stack">${rows.length ? rows.map(card).join('')
+          : `<p class="none">${col.label} is empty.</p>`}</div>
+      </section>`
+    }).join('')
+    const owed = mine.filter((c) => c.key !== 'done').length
+    const over = mine.filter((c) => c.overdue && c.key !== 'done').length
+    $('bcount').textContent = mine.length
+      ? `${owed} owed${over ? `, ${over} past due` : ''} · sorted by rot — deadline, then age, then isolation`
+      : ''
+    $('bsay').textContent = `${init}: ${owed} open, ${mine.length} cards total`
+  }
+
+  // ── the detail strip ──────────────────────────────────────────────────────
+  // A read-only board still has to let you act. Rather than a copy button on
+  // every card — which would put 200+ controls in the tab order — the picked
+  // card opens one strip that holds the full text and the two commands.
+  function drawDetail() {
+    const c = CARDS.find((x) => x.id === picked)
+    const strip = $('bdetail')
+    strip.hidden = !c
+    if (!c) return
+    const from = c.island
+      ? `<span class="isle">nothing links to this card yet</span>`
+      : `out of <b>${esc(deslug(N[c.src] ? N[c.src].name : ''))}</b>`
+    strip.innerHTML = `
+      <div class="dtext">
+        <p class="dbody">${esc(c.text)}</p>
+        <p class="dmeta">${esc(c.init || '—')}<span class="sep">·</span>${c.age == null ? '—' : days(c.age)}
+          ${c.due ? `<span class="sep">·</span><span class="${c.overdue ? 'due' : 'soft'}">due ${esc(c.due)}</span>` : ''}
+          <span class="sep">·</span>${from}</p>
+      </div>
+      <div class="dacts">
+        <button type="button" class="btn" data-open="${esc(c.id)}">Open in reader</button>
+        <button type="button" class="btn cp" data-copy="set_status ${esc(c.name)} in-progress">Copy “set_status”</button>
+        <button type="button" class="btn cp" data-copy="done ${esc(c.name)}">Copy “done”</button>
+        <button type="button" class="btn" data-close="1" aria-label="Close card details">✕</button>
+      </div>`
+  }
+
+  function pick(id) { picked = picked === id ? null : id; drawColumns(); drawDetail() }
+
+  // ── wiring ────────────────────────────────────────────────────────────────
+  $('bcols').addEventListener('click', (e) => {
+    const b = e.target.closest('[data-card]'); if (b) pick(b.dataset.card)
+  })
+  $('bdetail').addEventListener('click', (e) => {
+    const b = e.target.closest('button'); if (!b) return
+    if (b.dataset.close) { picked = null; drawColumns(); drawDetail(); return }
+    if (b.dataset.open) { onOpenNode(b.dataset.open); return }
+    if (!b.dataset.copy) return
+    navigator.clipboard?.writeText(b.dataset.copy)
+    // Keep the label out of the state: two quick clicks used to leave "Copied"
+    // as the button's own text forever.
+    clearTimeout(copyTimer)
+    $('bdetail').querySelectorAll('.cp').forEach((x) => x.classList.remove('ok'))
+    b.classList.add('ok')
+    $('bsay').textContent = `Copied: ${b.dataset.copy}`
+    copyTimer = setTimeout(() => b.classList.remove('ok'), 1400)
+  })
+  const pickInit = $('bInit')
+  pickInit.innerHTML = OWNERS.map(([k, n]) => `<option value="${esc(k)}">${esc(k)} — ${n} open</option>`).join('')
+  pickInit.addEventListener('change', () => { init = pickInit.value; picked = null; drawColumns(); drawDetail() })
+
+  return {
+    /** Open the board, optionally on a named initiative. */
+    show(name) {
+      if (name && OWNERS.some(([k]) => k === name)) init = name
+      if (!init) return false
+      pickInit.value = init
+      picked = null
+      drawColumns(); drawDetail()
+      // The cards read fine on excerpts; the detail strip is where the whole
+      // text belongs, so fetch it in the background and repaint if it lands.
+      loadFullBodies().then((full) => {
+        let grew = false
+        for (const c of CARDS) if (full[c.id] && full[c.id] !== c.text) { c.text = full[c.id]; grew = true }
+        if (grew) { drawColumns(); drawDetail() }
+      })
+      return true
+    },
+    initiative: () => init,
+  }
+}

--- a/kaeru-viz/src/board.js
+++ b/kaeru-viz/src/board.js
@@ -148,9 +148,9 @@ export function createBoard(data, { onOpenNode }) {
     if (everUsed.has(col.key) || col.key === COLUMNS[0].key) {
       return `<p class="none">${col.label} is empty.</p>`
     }
-    return `<p class="none">Nothing has ever been in ${col.label}.
-      A card gets here with <code>set_status &lt;task&gt; ${esc(col.key)}</code> —
-      the board reads, the vault writes.</p>`
+    return `<p class="none">Nothing has ever been in ${col.label}. The board reads;
+      the vault writes — a card gets here from the chat:</p>
+      <code class="cmd">set_status &lt;task&gt; ${esc(col.key)}</code>`
   }
 
   function drawColumns() {

--- a/kaeru-viz/src/board.js
+++ b/kaeru-viz/src/board.js
@@ -141,6 +141,18 @@ export function createBoard(data, { onOpenNode }) {
       <span class="meta">${init === ALL && c.init ? `<span class="owner">${esc(c.init)}</span>` : ''}<span class="age">${c.age == null ? '—' : days(c.age)}</span>${flags ? `<span class="sep">·</span>${flags}` : ''}</span>
     </button>`
   }
+  // A column nothing has ever reached is not "empty", it is unused — and since
+  // this room cannot move a card, saying so is more use than saying nothing.
+  const everUsed = new Set(CARDS.map((c) => c.key))
+  function emptyCol(col) {
+    if (everUsed.has(col.key) || col.key === COLUMNS[0].key) {
+      return `<p class="none">${col.label} is empty.</p>`
+    }
+    return `<p class="none">Nothing has ever been in ${col.label}.
+      A card gets here with <code>set_status &lt;task&gt; ${esc(col.key)}</code> —
+      the board reads, the vault writes.</p>`
+  }
+
   function drawColumns() {
     const scoped = inScope()
     const mine = scoped.filter(passes)
@@ -150,8 +162,7 @@ export function createBoard(data, { onOpenNode }) {
         .sort((a, b) => (col.key === 'done' ? (b.age == null) - (a.age == null) || a.age - b.age : b.rot - a.rot))
       return `<section class="col" aria-labelledby="col-${col.key}">
         <header class="colhead"><h2 id="col-${col.key}">${col.label}</h2><span class="n">${rows.length}</span></header>
-        <div class="stack">${rows.length ? rows.map(card).join('')
-          : `<p class="none">${col.label} is empty.</p>`}</div>
+        <div class="stack">${rows.length ? rows.map(card).join('') : emptyCol(col)}</div>
       </section>`
     }).join('')
     if (!mine.length && filtering()) {

--- a/kaeru-viz/src/bodies.js
+++ b/kaeru-viz/src/bodies.js
@@ -1,0 +1,34 @@
+// Full node bodies, fetched once and shared by every room that needs them.
+//
+// The galaxy only ever needs excerpts, so `/graph.json` truncates them. The
+// reader and the board both want the whole text, and both want it lazily —
+// pay for the heavier payload the first time a room actually opens, not on
+// page load.
+//
+// The cache is only set on success: a transient failure must leave the next
+// call free to retry rather than stranding the session on excerpts.
+
+let cached = null
+let inFlight = null
+
+/** Resolves to a `{ [nodeId]: body }` map, or `{}` when the daemon is out. */
+export function loadFullBodies() {
+  if (cached) return Promise.resolve(cached)
+  if (inFlight) return inFlight
+  inFlight = (async () => {
+    for (const url of ['/graph.json?bodies=true', './graph.json?bodies=true']) {
+      try {
+        const r = await fetch(url)
+        if (!r.ok) continue
+        const g = await r.json()
+        const out = {}
+        for (const n of g.nodes) if (n.body) out[n.id] = n.body
+        cached = out
+        return out
+      } catch (_) { /* fall through to the baked snapshot */ }
+    }
+    inFlight = null          // nothing arrived — let the next open try again
+    return {}
+  })()
+  return inFlight
+}

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -897,22 +897,7 @@ addEventListener('keydown', (e) => {
 })
 
 // ── loop ─────────────────────────────────────────────────────────────────────
-// The console's rule between rows only makes sense once it actually wraps.
-// Watched rather than measured on `resize`: the panel also reflows when a
-// dropdown label changes width, and a resize handler reads the old layout.
-function markPanelWrap() {
-  const segs = [...$('panel').querySelectorAll('.seg')]
-  if (!segs.length) return
-  const tops = new Set(segs.map((s) => Math.round(s.getBoundingClientRect().top)))
-  $('panel').classList.toggle('wrapped', tops.size > 1)
-}
-new ResizeObserver(markPanelWrap).observe($('panel'))
-markPanelWrap()
-addEventListener('resize', () => {
-  camera.aspect = innerWidth / innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth, innerHeight)
-  // after the frame, so the reflow the resize caused has actually happened
-  requestAnimationFrame(markPanelWrap)
-})
+addEventListener('resize', () => { camera.aspect = innerWidth / innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth, innerHeight) })
 let t = 0
 function loop() {
   requestAnimationFrame(loop); t += 1

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -538,6 +538,8 @@ async function setReader(on, nodeId) {
   if (on) { setHover(-1); chip.style.display = 'none' }   // drop the galaxy's hover chip
   readBtn.classList.toggle('go', on)
   readBtn.textContent = on ? 'galaxy' : 'read'
+  const out = $('rBack')
+  if (out) out.textContent = on && readerCameFromBoard ? '← board' : 'galaxy'
   // the panel stays; the rest of the galaxy's chrome belongs to the galaxy
   // Reading is its own room. Colour-by, focus, time-lapse, node search and the
   // project list are all instruments for surveying the galaxy; none of them
@@ -547,19 +549,29 @@ async function setReader(on, nodeId) {
   $('readout').hidden = on
   $('hud').hidden = on
 }
-readBtn.addEventListener('click', () => setReader(!readerOpen))
-$('rBack').addEventListener('click', () => setReader(false))
+readBtn.addEventListener('click', () => { readerCameFromBoard = false; setReader(!readerOpen) })
+$('rBack').addEventListener('click', () => {
+  const toBoard = readerCameFromBoard
+  setReader(false)
+  if (toBoard) setBoard(true, board.initiative())
+})
 // Escape leaves the reader — the reader covers the whole page, and every other
 // overlay here already closes that way. (Backspace steps back inside it.)
 addEventListener('keydown', (e) => {
   if (e.key !== 'Escape' || !readerOpen) return
   if (/^(INPUT|TEXTAREA)$/.test(e.target.tagName)) return
-  e.preventDefault(); setReader(false)
+  e.preventDefault()
+  // the board's own Escape handler is registered after this one; without
+  // stopping here it would close the board this press just re-opened.
+  e.stopImmediatePropagation()
+  const toBoard = readerCameFromBoard
+  setReader(false)
+  if (toBoard) setBoard(true, board.initiative())
 })
 // the readout is rebuilt on every hover, so delegate rather than re-bind
 $('readout').addEventListener('click', (e) => {
   const b = e.target.closest('[data-read]')
-  if (b) setReader(true, b.dataset.read)
+  if (b) { readerCameFromBoard = false; setReader(true, b.dataset.read) }
 })
 // picking another chain while reading re-reads it
 chainPick.addEventListener('change', () => { if (readerOpen) setReader(true) })
@@ -570,11 +582,13 @@ chainPick.addEventListener('change', () => { if (readerOpen) setReader(true) })
 // endpoint does not have. So the board shows the command instead of running it.
 const boardBtn = $('boardBtn')
 let boardOpen = false
+// where the reader was opened from, so its way out leads back there
+let readerCameFromBoard = false
 const board = createBoard(data, {
-  onOpenNode: (id) => { setBoard(false); setReader(true, id) },
+  onOpenNode: (id) => { setBoard(false); readerCameFromBoard = true; setReader(true, id) },
 })
 function setBoard(on, initiative) {
-  if (on && !board.show(initiative || focusEl.value || null)) return
+  if (on && !board.show(initiative || focusEl.value || '*')) return
   boardOpen = on
   $('board').hidden = !on
   if (on) { setHover(-1); chip.style.display = 'none' }
@@ -594,7 +608,7 @@ addEventListener('keydown', (e) => {
   e.preventDefault(); setBoard(false)
 })
 // the galaxy's project focus and the board's initiative are the same choice
-focusEl.addEventListener('change', () => { if (boardOpen) setBoard(true, focusEl.value || null) })
+focusEl.addEventListener('change', () => { if (boardOpen) setBoard(true, focusEl.value || '*') })
 
 // custom archive-styled dropdowns over the (hidden) native selects
 function makeDropdown(sel) {

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -897,7 +897,22 @@ addEventListener('keydown', (e) => {
 })
 
 // ── loop ─────────────────────────────────────────────────────────────────────
-addEventListener('resize', () => { camera.aspect = innerWidth / innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth, innerHeight) })
+// The console's rule between rows only makes sense once it actually wraps.
+// Watched rather than measured on `resize`: the panel also reflows when a
+// dropdown label changes width, and a resize handler reads the old layout.
+function markPanelWrap() {
+  const segs = [...$('panel').querySelectorAll('.seg')]
+  if (!segs.length) return
+  const tops = new Set(segs.map((s) => Math.round(s.getBoundingClientRect().top)))
+  $('panel').classList.toggle('wrapped', tops.size > 1)
+}
+new ResizeObserver(markPanelWrap).observe($('panel'))
+markPanelWrap()
+addEventListener('resize', () => {
+  camera.aspect = innerWidth / innerHeight; camera.updateProjectionMatrix(); renderer.setSize(innerWidth, innerHeight)
+  // after the frame, so the reflow the resize caused has actually happened
+  requestAnimationFrame(markPanelWrap)
+})
 let t = 0
 function loop() {
   requestAnimationFrame(loop); t += 1

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -615,21 +615,37 @@ function makeDropdown(sel) {
   sel.style.display = 'none'
   const dd = document.createElement('div'); dd.className = 'dd'
   const trig = document.createElement('div'); trig.className = 'dd-trigger'; trig.tabIndex = 0
+  // the native <select> is display:none, so its <label for> names nothing a
+  // screen reader can reach — carry the name onto the visible control.
+  trig.setAttribute('role', 'combobox')
+  trig.setAttribute('aria-haspopup', 'listbox')
+  trig.setAttribute('aria-expanded', 'false')
+  const lbl = sel.id && document.querySelector(`label[for="${sel.id}"]`)
+  if (lbl) trig.setAttribute('aria-label', lbl.textContent.trim())
   const lab = document.createElement('span'); lab.className = 'dd-label'
   const car = document.createElement('span'); car.className = 'dd-caret'
   trig.append(lab, car)
   const menu = document.createElement('div'); menu.className = 'dd-menu'; menu.hidden = true
+  menu.setAttribute('role', 'listbox')
   dd.append(trig, menu); sel.after(dd)
-  const close = () => { menu.hidden = true; trig.classList.remove('open'); document.removeEventListener('pointerdown', outside, true) }
+  const close = () => { menu.hidden = true; trig.classList.remove('open')
+    trig.setAttribute('aria-expanded', 'false')
+    document.removeEventListener('pointerdown', outside, true) }
   const outside = (e) => { if (!dd.contains(e.target)) close() }
   function sync() {
     const o = sel.selectedOptions[0]; lab.textContent = o ? o.textContent : ''
-    ;[...menu.children].forEach((c) => c.classList.toggle('sel', c.dataset.value === sel.value))
+    ;[...menu.children].forEach((c) => {
+      const on = c.dataset.value === sel.value
+      c.classList.toggle('sel', on)
+      c.setAttribute('aria-selected', String(on))
+    })
   }
   function rebuild() {
     menu.innerHTML = ''
     for (const o of sel.options) {
       const it = document.createElement('div'); it.className = 'dd-opt'; it.dataset.value = o.value
+      it.setAttribute('role', 'option')
+      it.setAttribute('aria-selected', String(o.value === sel.value))
       const m = o.textContent.match(/^(.*?)\s*\(([^)]+)\)\s*$/)   // split trailing "(count)" → dim, right-aligned
       const l = document.createElement('span'); l.className = 'dd-optlabel'; l.textContent = m ? m[1] : o.textContent
       it.append(l)
@@ -639,11 +655,22 @@ function makeDropdown(sel) {
     }
     sync()
   }
-  trig.addEventListener('click', () => { if (menu.hidden) { rebuild(); menu.hidden = false; trig.classList.add('open'); document.addEventListener('pointerdown', outside, true) } else close() })
+  const open = () => { rebuild(); menu.hidden = false; trig.classList.add('open')
+    trig.setAttribute('aria-expanded', 'true')
+    document.addEventListener('pointerdown', outside, true) }
+  trig.addEventListener('click', () => { if (menu.hidden) open(); else close() })
+  // a focusable control has to answer the keyboard too
+  trig.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') { e.preventDefault(); menu.hidden ? open() : close() }
+    else if (e.key === 'Escape' && !menu.hidden) { e.stopPropagation(); close() }
+  })
   sel._sync = sync; rebuild()
   return sync
 }
+// the board's picker lives in a TOP bar, so its menu drops down instead of up
 ;['chainPick', 'colorMode', 'focus'].forEach((id) => makeDropdown($(id)))
+makeDropdown($('bInit')).call && 0
+$('bInit').nextElementSibling.classList.add('down')
 
 // ── HUD + legend ─────────────────────────────────────────────────────────────
 const m = data.meta

--- a/kaeru-viz/src/main.js
+++ b/kaeru-viz/src/main.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import { createReader } from './reader.js'
+import { createBoard } from './board.js'
 
 // ── helpers ───────────────────────────────────────────────────────────────
 const esc = (s) => String(s ?? '').replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]))
@@ -563,6 +564,38 @@ $('readout').addEventListener('click', (e) => {
 // picking another chain while reading re-reads it
 chainPick.addEventListener('change', () => { if (readerOpen) setReader(true) })
 
+// ── board: the same tasks, owed instead of surveyed ─────────────────────────
+// Read-only by design: `/graph.json` carries the `status:*` tags a card's
+// column is made of, but moving a card is `set_status` — a write the viz
+// endpoint does not have. So the board shows the command instead of running it.
+const boardBtn = $('boardBtn')
+let boardOpen = false
+const board = createBoard(data, {
+  onOpenNode: (id) => { setBoard(false); setReader(true, id) },
+})
+function setBoard(on, initiative) {
+  if (on && !board.show(initiative || focusEl.value || null)) return
+  boardOpen = on
+  $('board').hidden = !on
+  if (on) { setHover(-1); chip.style.display = 'none' }
+  boardBtn.classList.toggle('go', on)
+  boardBtn.textContent = on ? 'galaxy' : 'board'
+  // the board is its own room, same as the reader
+  $('panel').hidden = on
+  $('rail').hidden = on
+  $('readout').hidden = on
+  $('hud').hidden = on
+}
+boardBtn.addEventListener('click', () => setBoard(!boardOpen))
+$('bBack').addEventListener('click', () => setBoard(false))
+addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape' || !boardOpen) return
+  if (/^(INPUT|TEXTAREA|SELECT)$/.test(e.target.tagName)) return
+  e.preventDefault(); setBoard(false)
+})
+// the galaxy's project focus and the board's initiative are the same choice
+focusEl.addEventListener('change', () => { if (boardOpen) setBoard(true, focusEl.value || null) })
+
 // custom archive-styled dropdowns over the (hidden) native selects
 function makeDropdown(sel) {
   sel.style.display = 'none'
@@ -751,6 +784,7 @@ function goToNode(i) {
   if (!visible(n)) { timeFilter = Infinity; timeEl.value = 100; timeLabel('— full graph —') }
   if (focusInit && n.init !== focusInit) setFocus(null)
   if (readerOpen) setReader(false)
+  if (boardOpen) setBoard(false)
   chain.clear(); nodes.forEach((x) => { x.__visited = false; x.__cur = false })
   pinNode(i); flyTo(n.pos, reducedMotion.matches ? 0 : 1100)
   say(`Showing ${n.name}`)
@@ -817,7 +851,7 @@ findInput.addEventListener('keydown', (e) => {
 // "/" focuses the search, the way every other tool does it
 addEventListener('keydown', (e) => {
   // the rail is gone while reading, so focusing its input would be a no-op
-  if (e.key !== '/' || e.target.tagName === 'INPUT' || !$('script').hidden || readerOpen) return
+  if (e.key !== '/' || e.target.tagName === 'INPUT' || !$('script').hidden || readerOpen || boardOpen) return
   e.preventDefault(); findInput.focus(); findInput.select()
 })
 
@@ -843,7 +877,7 @@ function loop() {
   controls.autoRotate = !reducedMotion.matches && !(window.__rec && window.__rec.active) &&
     hovered < 0 && !chain.size && !focusInit && $('script').hidden && !tween
   controls.update()
-  if (!readerOpen) renderer.render(scene, camera)   // the reader covers the canvas
+  if (!readerOpen && !boardOpen) renderer.render(scene, camera)   // a room covers the canvas
 }
 
 // recording hook — only present with ?rec, drives a deterministic seamless orbit

--- a/kaeru-viz/src/reader.js
+++ b/kaeru-viz/src/reader.js
@@ -9,6 +9,8 @@
 // a one-lane DAG, so a linear trail and a branching deep-research share one
 // layout instead of two.
 
+import { loadFullBodies } from './bodies.js'
+
 // same layer ramp the galaxy's readout bar uses
 const LAYER_ACCENT = { core: '#caa24a', hot: '#c8402e', warm: '#7e96cf', cold: '#6f7da0', frozen: '#8a8578' }
 const REL = {
@@ -57,7 +59,6 @@ export function createReader(data, { fmtDateTime }) {
   let chain = null, steps = [], POS = {}, lanes = 0, shared = new Map(), research = new Set()
   let hist = []                 // trail of what was read before this
   let tx = 60, ty = 40, scale = 0.62, view = 'trail'
-  let bodiesLoaded = false
 
   // ── text ────────────────────────────────────────────────────────────────
   const inline = (t) => esc(t)
@@ -72,20 +73,10 @@ export function createReader(data, { fmtDateTime }) {
   const when = (n) => (n.created_secs ? fmtDateTime(n.created_secs) : '—')
   const h = (s) => { const d = document.createElement('div'); d.innerHTML = s.trim(); return d.firstChild }
 
-  // The galaxy only needs excerpts; a reader needs the whole body. Pay for the
-  // heavier payload once, the first time the reader is actually opened.
+  // The galaxy only needs excerpts; a reader needs the whole body.
   async function loadBodies() {
-    if (bodiesLoaded) return
-    for (const url of ['/graph.json?bodies=true', './graph.json?bodies=true']) {
-      try {
-        const r = await fetch(url)
-        if (!r.ok) continue
-        const g = await r.json()
-        for (const n of g.nodes) if (N[n.id] && n.body) N[n.id].body = n.body
-        bodiesLoaded = true   // only once it actually arrived: a transient
-        return                // failure must leave the next open free to retry
-      } catch (_) { /* fall through to the baked snapshot */ }
-    }
+    const full = await loadFullBodies()
+    for (const id in full) if (N[id]) N[id].body = full[id]
   }
 
   // ── layout: derivation DAG, lanes by path decomposition ─────────────────

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -456,14 +456,30 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 #bdbody { flex: 1; min-height: 0; overflow-y: auto; padding: 16px 18px 20px; }
 #bdbody .dbody { margin: 0; font-family: var(--serif); font-size: 15px; line-height: 1.55;
   color: var(--fg); white-space: pre-wrap; }
-#bdbody dl { display: grid; grid-template-columns: max-content 1fr; gap: 9px 16px;
-  margin: 20px 0 0; padding-top: 16px; border-top: 1px solid var(--line); }
+/* One gutter, one baseline. Labels share a right edge and every value sits
+   on the same line, so the block reads as a table rather than a ragged list. */
+/* Top-aligned, not baseline-aligned: the provenance value is a <button>, and
+   an inline-block's baseline is its LAST line — so a value that wraps used to
+   drag its label down beside the second line. */
+#bdbody dl { display: grid; grid-template-columns: max-content 1fr; gap: 11px 18px;
+  align-items: start; margin: 20px 0 0; padding-top: 16px;
+  border-top: 1px solid var(--line); }
 #bdbody dt { font-family: var(--mono); font-size: 9.5px; letter-spacing: .16em;
-  text-transform: uppercase; color: var(--fg-2); padding-top: 2px; }
-#bdbody dd { margin: 0; font-family: var(--serif); font-size: 13.5px; color: var(--fg); }
-#bdbody dd .mono { font-family: var(--mono); font-size: 11.5px; }
+  text-transform: uppercase; color: var(--fg-2); text-align: right; padding-top: .34em; }
+#bdbody dd { margin: 0; font-family: var(--mono); font-size: 12px; line-height: 1.45;
+  color: var(--fg); }
+#bdbody dd .name { font-family: var(--serif); font-size: 13.5px; }
 #bdbody dd .due { color: #fff; background: var(--seal); border-radius: 3px; padding: 2px 6px;
   font-family: var(--mono); font-size: 11px; }
+/* the provenance is a way in, not a caption */
+.nodelink { font-family: var(--serif); font-size: 13.5px; line-height: 1.45; text-align: left;
+  color: var(--fg); background: none; border: 0; padding: 0; cursor: pointer;
+  text-decoration: underline; text-decoration-color: var(--line-2);
+  text-underline-offset: 3px; text-decoration-thickness: from-font; }
+.nodelink:hover { text-decoration-color: currentColor; }
+/* whose card this is, shown only when the board spans every initiative */
+.card .owner { color: var(--fg); background: var(--ctl-bg); border: 1px solid var(--line-2);
+  border-radius: 3px; padding: 2px 6px; }
 /* deliberate rows rather than a ragged wrap: the way in on top, the two
    commands you copy underneath */
 #bdacts { flex: none; display: grid; grid-template-columns: 1fr 1fr; gap: 8px;

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -436,9 +436,12 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .stack { flex: 1; min-height: 0; overflow-y: auto; padding: 10px; }
 .none { margin: 10px 3px; font-family: var(--serif); font-style: italic;
   font-size: 13px; line-height: 1.55; color: var(--fg-2); }
-.none code { font-family: var(--mono); font-style: normal; font-size: 11px;
-  color: var(--fg); background: var(--panel); border: 1px solid var(--line);
-  border-radius: 3px; padding: 1px 5px; }
+/* the command is a block, not an inline chip: in a 274px lane an inline
+   <code> wraps mid-token and draws its box twice */
+.stack .cmd { display: block; margin: 10px 3px 0; font-family: var(--mono);
+  font-size: 11px; line-height: 1.5; color: var(--fg); background: var(--panel);
+  border: 1px solid var(--line); border-radius: 4px; padding: 8px 10px;
+  white-space: nowrap; overflow-x: auto; }
 
 /* the card — an object lying on the lane */
 .card { display: block; width: 100%; text-align: left; font: inherit; color: inherit;

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -67,19 +67,35 @@ html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
 .stats .span .sub { color: var(--faint); margin-top: 3px; }
 
 /* ── console (bottom toolbar) ─────────────────────────── */
-/* The console has to wrap. Its content is 1683px wide and a 1280px window
-   gives it 1234 — without wrapping the theme switch and the whole time-lapse
-   segment were simply clipped off the right edge, unreachable. */
+/* One row, always. The console used to need 1683px in the 1234 a 1280px
+   window gives it, so the theme switch and the whole time-lapse segment sat
+   past the right edge — not cramped, unreachable. It stays one row and the
+   pickers absorb the pressure instead: `nowrap` is what lets flex shrink
+   them at all (with `wrap` the browser moves items to a second line rather
+   than narrowing them). `overflow-x` is the last resort, not the plan. */
 #panel { position: fixed; left: 22px; right: 22px; bottom: 20px; z-index: 10;
   background: var(--panel); border: 1px solid var(--line-2); border-radius: 6px;
-  display: flex; flex-wrap: wrap; align-items: stretch; }
-.seg { display: flex; align-items: flex-end; gap: 10px; padding: 11px 18px;
+  display: flex; flex-wrap: nowrap; align-items: stretch; overflow-x: auto; }
+.seg { display: flex; align-items: flex-end; gap: 8px; padding: 10px 12px;
   border-right: 1px solid var(--line); }
-/* a wrapped row needs a rule above it, or the two rows read as one soup */
-.seg { border-top: 1px solid transparent; }
-#panel.wrapped .seg { border-top-color: var(--line); }
 .seg:last-child { border-right: 0; flex: 1; }
-.seg.scrub { min-width: 340px; }
+.seg.scrub { min-width: 120px; }
+/* the time-lapse caption yields first when the console is tight. Every
+   ancestor needs min-width:0 or a flex item refuses to shrink past its
+   content, and the row overflows its segment instead. */
+.seg.scrub .field, .seg.scrub .trackrow { min-width: 0; }
+.seg.scrub .val { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+/* Below this the caption cannot be read anyway — drop it whole rather than
+   leave a three-character stub, and give the slider the width back. */
+@media (max-width: 1360px) { .seg.scrub .val { display: none; } }
+/* The console's pickers absorb the pressure: full width when the row has
+   room, ellipsised only when it doesn't. Buttons never squash — a label
+   clipped mid-word is worse than a truncated chain name. */
+#panel .seg, #panel .field, #panel .dd { min-width: 0; }
+#panel .btn, #panel .themeseg, #panel .toggle { flex: none; }
+/* The pickers are the only elastic thing here, so they carry the trim: the
+   full name is one click away in the menu, a clipped button label is not. */
+#panel .dd-trigger, #panel select.ctl { max-width: 130px; }
 .field { display: flex; flex-direction: column; gap: 6px; }
 .field label { font-family: var(--mono); font-size: 9.5px; letter-spacing: .18em;
   text-transform: uppercase; color: var(--dim); height: 11px; line-height: 11px; white-space: nowrap; }
@@ -121,10 +137,10 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
 .dd-opt.sel { background: rgba(200, 64, 46, .12); }
 .dd-opt.sel::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--seal); }
 
-.btn { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+.btn { font-family: var(--mono); font-size: 11px; letter-spacing: .09em; text-transform: uppercase;
   border: 1px solid var(--line-2); background: transparent; color: var(--fg); height: 30px;
-  display: inline-flex; align-items: center; border-radius: 3px; padding: 0 13px; cursor: pointer;
-  white-space: nowrap;   /* "guided tour" was breaking across two lines */
+  display: inline-flex; align-items: center; border-radius: 3px; padding: 0 11px; cursor: pointer;
+  white-space: nowrap;   /* labels must never break across two lines */
   transition: border-color .15s, background .15s; }
 .btn:hover { background: var(--ctl-bg); }
 .btn.go { border-color: var(--seal); color: var(--seal-fg); }
@@ -151,7 +167,7 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
   border-radius: 3px; overflow: hidden; }
 .themeseg button { font-family: var(--mono); font-size: 11px; letter-spacing: .06em;
   text-transform: uppercase; background: var(--ctl-bg); color: var(--dim); border: 0;
-  border-left: 1px solid var(--line-2); padding: 0 11px; cursor: pointer;
+  border-left: 1px solid var(--line-2); padding: 0 8px; cursor: pointer;
   transition: background .15s, color .15s; }
 .themeseg button:first-child { border-left: 0; }
 .themeseg button:hover { color: var(--fg); }
@@ -159,10 +175,10 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
 
 /* time-lapse */
 .scrub { flex: 1; }
-.trackrow { display: flex; align-items: center; gap: 13px; height: 30px; }
+.trackrow { display: flex; align-items: center; gap: 10px; height: 30px; min-width: 0; }
 .val { font-family: var(--mono); font-size: 11px; color: var(--dim); white-space: nowrap;
   font-variant-numeric: tabular-nums; }
-input[type=range] { flex: 1; min-width: 160px; -webkit-appearance: none; appearance: none;
+input[type=range] { flex: 1; min-width: 60px; -webkit-appearance: none; appearance: none;
   height: 2px; background: var(--line-2); border-radius: 2px; cursor: pointer; }
 input[type=range]::-webkit-slider-thumb { -webkit-appearance: none; width: 12px; height: 12px;
   border-radius: 50%; background: var(--gold); border: none; }

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -16,6 +16,7 @@
   --panel-2: rgba(23, 23, 27, 0.72);
   --ctl-bg: #1f1f24;
   --gold: #caa24a;
+  --warn: #caa24a;      /* gold reads on the dark ground */
   --seal-fg: #f0d9d3;
 }
 /* light theme — "aged paper" (brandbook v2 face palette) */
@@ -24,14 +25,14 @@
     --bg: #fcfbf8; --fg: #35312a; --fg-2: #544d42; --dim: #6e6557; --faint: #a99e8c;
     --line: rgba(53, 49, 42, 0.14); --line-2: rgba(53, 49, 42, 0.20);
     --panel: #eee9d8; --panel-2: rgba(238, 233, 216, 0.86); --ctl-bg: #f4efe6;
-    --gold: #caa24a; --seal-fg: #8a2a1a;
+    --gold: #caa24a; --warn: #8a6b24; --seal-fg: #8a2a1a;
   }
 }
 :root[data-theme="light"] {
   --bg: #fcfbf8; --fg: #35312a; --fg-2: #544d42; --dim: #6e6557; --faint: #a99e8c;
   --line: rgba(53, 49, 42, 0.14); --line-2: rgba(53, 49, 42, 0.20);
   --panel: #eee9d8; --panel-2: rgba(238, 233, 216, 0.86); --ctl-bg: #f4efe6;
-  --gold: #caa24a; --seal-fg: #8a2a1a;
+  --gold: #caa24a; --warn: #8a6b24; --seal-fg: #8a2a1a;
 }
 * { box-sizing: border-box; }
 html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
@@ -282,10 +283,10 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   background: color-mix(in srgb, var(--panel) 92%, transparent);
   border-bottom: 1px solid var(--line); backdrop-filter: blur(8px); }
 #rbar #rPrev { border-color: var(--seal); color: var(--seal-fg); }
-#rbar .rtitle { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
-#rbar .rkind { font-family: var(--mono); font-size: 9px; letter-spacing: .2em;
+#rbar .rtitle, #bbar .rtitle { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+#rbar .rkind, #bbar .rkind { font-family: var(--mono); font-size: 9px; letter-spacing: .2em;
   text-transform: uppercase; color: var(--seal); }
-#rbar .rtitle b { font-family: var(--serif); font-weight: 500; font-size: 17px;
+#rbar .rtitle b, #bbar .rtitle b { font-family: var(--serif); font-weight: 500; font-size: 17px;
   letter-spacing: -.01em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #rbar #rView { margin-left: auto; }
 #rhint { position: absolute; bottom: 22px; left: 24px; z-index: 9; font-family: var(--mono);
@@ -373,6 +374,76 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .rmark { background: color-mix(in srgb, var(--gold) 22%, transparent); border-radius: 2px; padding: 0 3px; }
 #reader code { font-family: var(--mono); font-size: .88em; background: var(--ctl-bg);
   border: 1px solid var(--line); border-radius: 2px; padding: 0 4px; }
+
+/* ── board ────────────────────────────────────────────── */
+/* Same law as the reader: the field is the darker --panel, a card the lighter
+   --bg. Vermilion means ONE thing here — past due. Selection is a neutral
+   fill, so the two never read as the same signal. */
+#board { position: fixed; inset: 0; z-index: 8; background: var(--panel);
+  display: flex; flex-direction: column; }
+#bbar { flex: none; display: flex; align-items: center; gap: 18px; padding: 14px 22px;
+  background: var(--bg); border-bottom: 1px solid var(--line-2); flex-wrap: wrap; }
+#bbar .bpick { margin-left: auto; }
+.skip { position: absolute; top: 8px; left: 50%; transform: translate(-50%, -200%);
+  z-index: 20; font-family: var(--mono); font-size: 11px; color: var(--fg);
+  background: var(--ctl-bg); border: 1px solid var(--line-2); border-radius: 3px;
+  padding: 8px 14px; text-decoration: none; }
+.skip:focus { transform: translate(-50%, 0); }
+#bend { position: absolute; width: 1px; height: 1px; }
+
+#bcols { flex: 1; min-height: 0; display: flex; gap: 18px; align-items: stretch;
+  padding: 18px 22px 4px; overflow-x: auto; }
+.col { flex: 1 1 0; min-width: 274px; display: flex; flex-direction: column; min-height: 0; }
+.colhead { flex: none; display: flex; align-items: baseline; gap: 10px;
+  padding: 0 2px 10px; border-bottom: 1px solid var(--line-2); }
+.colhead h2 { margin: 0; font-family: var(--mono); font-size: 10.5px; font-weight: 400;
+  letter-spacing: .22em; text-transform: uppercase; color: var(--fg-2); }
+.colhead .n { margin-left: auto; font-family: var(--mono); font-size: 11px;
+  color: var(--fg-2); font-variant-numeric: tabular-nums; }
+.stack { flex: 1; min-height: 0; overflow-y: auto; padding: 10px 2px 20px; }
+.none { margin: 14px 2px; font-family: var(--serif); font-style: italic;
+  font-size: 13px; color: var(--fg-2); }
+
+.card { display: block; width: 100%; text-align: left; font: inherit; color: inherit;
+  background: var(--bg); border: 1px solid var(--line-2); border-left: 3px solid var(--line-2);
+  border-radius: 4px; padding: 11px 13px; margin-bottom: 8px; cursor: pointer;
+  transition: border-color .15s, background-color .15s; }
+.card:hover { border-color: var(--fg-2); }
+.card.overdue { border-left-color: var(--seal); }
+.card.picked { background: var(--ctl-bg); border-color: var(--fg); }
+.card .what { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;
+  overflow: hidden; font-family: var(--serif); font-size: 14.5px; line-height: 1.45;
+  color: var(--fg); text-wrap: pretty; }
+.card .meta { display: flex; flex-wrap: wrap; align-items: center; gap: 4px 7px; margin-top: 8px;
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-2); }
+.card .age { font-variant-numeric: tabular-nums; }
+.card .sep { color: var(--dim); }
+/* white on vermilion measures 4.62:1 in both themes; --seal-fg (3.68) and
+   near-black (3.88) both miss AA at this size */
+.card .due, #bdetail .dmeta .due { color: #fff; background: var(--seal);
+  border-radius: 2px; padding: 1px 5px; }
+.card .soft, #bdetail .soft { color: var(--fg-2); }
+.card .isle, #bdetail .isle { color: var(--warn); }
+
+#bcount { flex: none; margin: 0; padding: 6px 22px 14px; font-family: var(--mono);
+  font-size: 10.5px; letter-spacing: .04em; color: var(--fg-2); }
+#bdetail { flex: none; display: flex; align-items: flex-start; gap: 20px;
+  padding: 15px 22px; background: var(--bg); border-top: 1px solid var(--line-2); }
+#bdetail .dtext { flex: 1; min-width: 0; }
+#bdetail .dbody { margin: 0; font-family: var(--serif); font-size: 15px; line-height: 1.5;
+  color: var(--fg); max-width: 68ch; max-height: 8.4em; overflow-y: auto; }
+#bdetail .dmeta { margin: 8px 0 0; font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); display: flex; flex-wrap: wrap; align-items: center; gap: 4px 8px; }
+#bdetail .dmeta b { font-family: var(--serif); font-size: 12.5px; font-weight: 400; color: var(--fg); }
+#bdetail .sep { color: var(--dim); }
+#bdetail .dacts { flex: none; display: flex; flex-wrap: wrap; gap: 8px; }
+#bdetail .cp.ok { border-color: var(--warn); color: var(--warn); }
+
+@media (max-width: 720px) {
+  #bbar { gap: 12px; }
+  #bbar .bpick { margin-left: 0; width: 100%; }
+  #bdetail { flex-direction: column; gap: 12px; }
+}
 
 /* ── motion, only for those who want it ────────────────── */
 @media (prefers-reduced-motion: reduce) {

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -435,7 +435,10 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   border-radius: 10px; padding: 2px 8px; }
 .stack { flex: 1; min-height: 0; overflow-y: auto; padding: 10px; }
 .none { margin: 10px 3px; font-family: var(--serif); font-style: italic;
-  font-size: 13px; color: var(--fg-2); }
+  font-size: 13px; line-height: 1.55; color: var(--fg-2); }
+.none code { font-family: var(--mono); font-style: normal; font-size: 11px;
+  color: var(--fg); background: var(--panel); border: 1px solid var(--line);
+  border-radius: 3px; padding: 1px 5px; }
 
 /* the card — an object lying on the lane */
 .card { display: block; width: 100%; text-align: left; font: inherit; color: inherit;

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -96,6 +96,7 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
 .dd-caret { flex: none; width: 0; height: 0; border-left: 4px solid transparent; border-right: 4px solid transparent;
   border-top: 5px solid var(--dim); }
 .dd-trigger.open .dd-caret { border-top: 0; border-bottom: 5px solid var(--seal); }
+.dd.down .dd-menu { top: calc(100% + 5px); bottom: auto; }
 .dd-menu { position: absolute; left: 0; bottom: calc(100% + 5px); z-index: 30; min-width: 100%; width: max-content;
   max-width: 440px; max-height: 300px; overflow-y: auto; overflow-x: hidden; background: var(--panel);
   border: 1px solid var(--line-2); border-radius: 4px;
@@ -108,7 +109,7 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
   font-family: var(--mono); font-size: 12px; color: var(--fg); cursor: pointer; }
 .dd-opt:first-child { border-top: 0; }
 .dd-optlabel { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.dd-meta { flex: none; color: var(--faint); font-size: 11px; font-variant-numeric: tabular-nums; }
+.dd-meta { flex: none; color: var(--dim); font-size: 11px; font-variant-numeric: tabular-nums; }
 .dd-opt:hover { background: var(--ctl-bg); }
 .dd-opt.sel { background: rgba(200, 64, 46, .12); }
 .dd-opt.sel::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--seal); }
@@ -393,6 +394,30 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   padding: 8px 14px; text-decoration: none; }
 .skip:focus { transform: translate(-50%, 0); }
 #bend { position: absolute; width: 1px; height: 1px; }
+
+/* ── the filter bar ───────────────────────────────────── */
+/* Only `status:` and `due:` are tags a person sets, so the useful filters are
+   the derived ones — text, the three rot signals, and `topic:`. */
+#bfilter { flex: none; display: flex; align-items: center; flex-wrap: wrap; gap: 10px;
+  padding: 10px 22px; background: var(--bg); border-bottom: 1px solid var(--line); }
+#bFind { font-family: var(--mono); font-size: 12px; color: var(--fg); background: var(--ctl-bg);
+  border: 1px solid var(--line-2); border-radius: 3px; height: 30px; width: 232px;
+  padding: 0 10px; }
+#bFind::placeholder { color: var(--fg-2); }
+#bsieves { display: flex; flex-wrap: wrap; gap: 6px; }
+.sieve { font-family: var(--mono); font-size: 10.5px; letter-spacing: .06em; color: var(--fg-2);
+  background: var(--ctl-bg); border: 1px solid var(--line-2); border-radius: 13px;
+  height: 30px; padding: 0 12px; cursor: pointer; display: inline-flex; align-items: center; gap: 7px;
+  transition: border-color .15s, color .15s, background .15s; }
+.sieve:hover { color: var(--fg); }
+.sieve .c { font-variant-numeric: tabular-nums; color: var(--dim); }
+.sieve[aria-pressed="true"] { background: var(--fg); border-color: var(--fg); color: var(--bg); }
+/* no opacity on the count — a faded foreground is a contrast hole */
+.sieve[aria-pressed="true"] .c { color: var(--bg); }
+#bfilter #bClear { flex: none; }
+.nohits { margin: 40px auto; max-width: 46ch; text-align: center; font-family: var(--serif);
+  font-size: 15px; line-height: 1.6; color: var(--fg); }
+.nohits .btn { display: inline-flex; margin-top: 14px; }
 
 #bcols { flex: 1; min-height: 0; display: flex; gap: 16px; align-items: stretch;
   padding: 18px 22px 6px; overflow-x: auto; }

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -76,7 +76,7 @@ html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
 #panel { position: fixed; left: 22px; right: 22px; bottom: 20px; z-index: 10;
   background: var(--panel); border: 1px solid var(--line-2); border-radius: 6px;
   display: flex; flex-wrap: nowrap; align-items: stretch; overflow-x: auto; }
-.seg { display: flex; align-items: flex-end; gap: 8px; padding: 10px 12px;
+.seg { display: flex; align-items: flex-end; gap: 9px; padding: 11px 14px;
   border-right: 1px solid var(--line); }
 .seg:last-child { border-right: 0; flex: 1; }
 .seg.scrub { min-width: 120px; }
@@ -95,7 +95,13 @@ html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
 #panel .btn, #panel .themeseg, #panel .toggle { flex: none; }
 /* The pickers are the only elastic thing here, so they carry the trim: the
    full name is one click away in the menu, a clipped button label is not. */
-#panel .dd-trigger, #panel select.ctl { max-width: 130px; }
+#panel .dd-trigger, #panel select.ctl { max-width: 190px; }
+/* on a narrow window the pickers give up the last 90px instead of pushing
+   the time-lapse off the edge — the full name is one click away in the menu */
+@media (max-width: 1500px) {
+  #panel .dd-trigger, #panel select.ctl { max-width: 126px; }
+  .seg { padding-inline: 11px; gap: 8px; }
+}
 .field { display: flex; flex-direction: column; gap: 6px; }
 .field label { font-family: var(--mono); font-size: 9.5px; letter-spacing: .18em;
   text-transform: uppercase; color: var(--dim); height: 11px; line-height: 11px; white-space: nowrap; }
@@ -145,9 +151,12 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
 .btn:hover { background: var(--ctl-bg); }
 .btn.go { border-color: var(--seal); color: var(--seal-fg); }
 .btn.go:hover { background: rgba(200,64,46,.14); }
-.btn.go::before { content: ""; display: inline-block; width: 0; height: 0; margin-right: 7px;
-  border-left: 7px solid var(--seal); border-top: 4px solid transparent;
-  border-bottom: 4px solid transparent; vertical-align: 1px; }
+.btn.go::before { content: ""; display: inline-block; width: 0; height: 0; margin-right: 5px;
+  border-left: 6px solid var(--seal); border-top: 3.5px solid transparent;
+  border-bottom: 3.5px solid transparent; vertical-align: 1px; }
+/* replay is the widest button in the console — the marker already says "go",
+   so it carries the trim rather than the labels around it */
+#chainPlay { padding-inline: 9px 11px; }
 .btn.mini { width: 30px; padding: 0; justify-content: center; }
 .btn.mini::before { content: ""; width: 0; height: 0;
   border-left: 7px solid var(--fg); border-top: 4px solid transparent; border-bottom: 4px solid transparent; }
@@ -167,7 +176,7 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
   border-radius: 3px; overflow: hidden; }
 .themeseg button { font-family: var(--mono); font-size: 11px; letter-spacing: .06em;
   text-transform: uppercase; background: var(--ctl-bg); color: var(--dim); border: 0;
-  border-left: 1px solid var(--line-2); padding: 0 8px; cursor: pointer;
+  border-left: 1px solid var(--line-2); padding: 0 10px; cursor: pointer;
   transition: background .15s, color .15s; }
 .themeseg button:first-child { border-left: 0; }
 .themeseg button:hover { color: var(--fg); }

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -67,12 +67,19 @@ html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
 .stats .span .sub { color: var(--faint); margin-top: 3px; }
 
 /* ── console (bottom toolbar) ─────────────────────────── */
+/* The console has to wrap. Its content is 1683px wide and a 1280px window
+   gives it 1234 — without wrapping the theme switch and the whole time-lapse
+   segment were simply clipped off the right edge, unreachable. */
 #panel { position: fixed; left: 22px; right: 22px; bottom: 20px; z-index: 10;
   background: var(--panel); border: 1px solid var(--line-2); border-radius: 6px;
-  display: flex; align-items: stretch; }
+  display: flex; flex-wrap: wrap; align-items: stretch; }
 .seg { display: flex; align-items: flex-end; gap: 10px; padding: 11px 18px;
   border-right: 1px solid var(--line); }
+/* a wrapped row needs a rule above it, or the two rows read as one soup */
+.seg { border-top: 1px solid transparent; }
+#panel.wrapped .seg { border-top-color: var(--line); }
 .seg:last-child { border-right: 0; flex: 1; }
+.seg.scrub { min-width: 340px; }
 .field { display: flex; flex-direction: column; gap: 6px; }
 .field label { font-family: var(--mono); font-size: 9.5px; letter-spacing: .18em;
   text-transform: uppercase; color: var(--dim); height: 11px; line-height: 11px; white-space: nowrap; }
@@ -117,6 +124,7 @@ select.ctl { appearance: none; padding-right: 26px; max-width: 280px;
 .btn { font-family: var(--mono); font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
   border: 1px solid var(--line-2); background: transparent; color: var(--fg); height: 30px;
   display: inline-flex; align-items: center; border-radius: 3px; padding: 0 13px; cursor: pointer;
+  white-space: nowrap;   /* "guided tour" was breaking across two lines */
   transition: border-color .15s, background .15s; }
 .btn:hover { background: var(--ctl-bg); }
 .btn.go { border-color: var(--seal); color: var(--seal-fg); }

--- a/kaeru-viz/src/style.css
+++ b/kaeru-viz/src/style.css
@@ -17,6 +17,7 @@
   --ctl-bg: #1f1f24;
   --gold: #caa24a;
   --warn: #caa24a;      /* gold reads on the dark ground */
+  --kind: #e8836f;      /* the kind label — seal itself is 2.88:1 here */
   --seal-fg: #f0d9d3;
 }
 /* light theme — "aged paper" (brandbook v2 face palette) */
@@ -25,14 +26,14 @@
     --bg: #fcfbf8; --fg: #35312a; --fg-2: #544d42; --dim: #6e6557; --faint: #a99e8c;
     --line: rgba(53, 49, 42, 0.14); --line-2: rgba(53, 49, 42, 0.20);
     --panel: #eee9d8; --panel-2: rgba(238, 233, 216, 0.86); --ctl-bg: #f4efe6;
-    --gold: #caa24a; --warn: #8a6b24; --seal-fg: #8a2a1a;
+    --gold: #caa24a; --warn: #8a6b24; --kind: #a8331f; --seal-fg: #8a2a1a;
   }
 }
 :root[data-theme="light"] {
   --bg: #fcfbf8; --fg: #35312a; --fg-2: #544d42; --dim: #6e6557; --faint: #a99e8c;
   --line: rgba(53, 49, 42, 0.14); --line-2: rgba(53, 49, 42, 0.20);
   --panel: #eee9d8; --panel-2: rgba(238, 233, 216, 0.86); --ctl-bg: #f4efe6;
-  --gold: #caa24a; --warn: #8a6b24; --seal-fg: #8a2a1a;
+  --gold: #caa24a; --warn: #8a6b24; --kind: #a8331f; --seal-fg: #8a2a1a;
 }
 * { box-sizing: border-box; }
 html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
@@ -285,7 +286,7 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 #rbar #rPrev { border-color: var(--seal); color: var(--seal-fg); }
 #rbar .rtitle, #bbar .rtitle { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 #rbar .rkind, #bbar .rkind { font-family: var(--mono); font-size: 9px; letter-spacing: .2em;
-  text-transform: uppercase; color: var(--seal); }
+  text-transform: uppercase; color: var(--kind); }
 #rbar .rtitle b, #bbar .rtitle b { font-family: var(--serif); font-weight: 500; font-size: 17px;
   letter-spacing: -.01em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #rbar #rView { margin-left: auto; }
@@ -376,9 +377,11 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
   border: 1px solid var(--line); border-radius: 2px; padding: 0 4px; }
 
 /* ── board ────────────────────────────────────────────── */
-/* Same law as the reader: the field is the darker --panel, a card the lighter
-   --bg. Vermilion means ONE thing here — past due. Selection is a neutral
-   fill, so the two never read as the same signal. */
+/* What makes a board read as a board is not the cards, it is the LANES: a
+   column has to be a container with its own surface, so the eye sees three
+   trays rather than three lists on one field. Three steps of recession —
+   field (--panel) < lane (--ctl-bg) < card (--bg) — in both themes.
+   Vermilion means ONE thing here: past due. */
 #board { position: fixed; inset: 0; z-index: 8; background: var(--panel);
   display: flex; flex-direction: column; }
 #bbar { flex: none; display: flex; align-items: center; gap: 18px; padding: 14px 22px;
@@ -391,58 +394,89 @@ input[type=range]::-moz-range-thumb { width: 12px; height: 12px; border-radius: 
 .skip:focus { transform: translate(-50%, 0); }
 #bend { position: absolute; width: 1px; height: 1px; }
 
-#bcols { flex: 1; min-height: 0; display: flex; gap: 18px; align-items: stretch;
-  padding: 18px 22px 4px; overflow-x: auto; }
-.col { flex: 1 1 0; min-width: 274px; display: flex; flex-direction: column; min-height: 0; }
-.colhead { flex: none; display: flex; align-items: baseline; gap: 10px;
-  padding: 0 2px 10px; border-bottom: 1px solid var(--line-2); }
-.colhead h2 { margin: 0; font-family: var(--mono); font-size: 10.5px; font-weight: 400;
-  letter-spacing: .22em; text-transform: uppercase; color: var(--fg-2); }
-.colhead .n { margin-left: auto; font-family: var(--mono); font-size: 11px;
-  color: var(--fg-2); font-variant-numeric: tabular-nums; }
-.stack { flex: 1; min-height: 0; overflow-y: auto; padding: 10px 2px 20px; }
-.none { margin: 14px 2px; font-family: var(--serif); font-style: italic;
+#bcols { flex: 1; min-height: 0; display: flex; gap: 16px; align-items: stretch;
+  padding: 18px 22px 6px; overflow-x: auto; }
+
+/* the lane — a tray, not a heading with a rule under it */
+.col { flex: 1 1 0; min-width: 286px; display: flex; flex-direction: column; min-height: 0;
+  background: var(--ctl-bg); border: 1px solid var(--line); border-radius: 7px; }
+.colhead { flex: none; display: flex; align-items: center; gap: 10px;
+  padding: 11px 13px 10px; border-bottom: 1px solid var(--line); }
+.colhead h2 { margin: 0; font-family: var(--mono); font-size: 10px; font-weight: 400;
+  letter-spacing: .2em; text-transform: uppercase; color: var(--fg-2); }
+.colhead .n { margin-left: auto; min-width: 22px; text-align: center;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  font-variant-numeric: tabular-nums; background: var(--panel);
+  border-radius: 10px; padding: 2px 8px; }
+.stack { flex: 1; min-height: 0; overflow-y: auto; padding: 10px; }
+.none { margin: 10px 3px; font-family: var(--serif); font-style: italic;
   font-size: 13px; color: var(--fg-2); }
 
+/* the card — an object lying on the lane */
 .card { display: block; width: 100%; text-align: left; font: inherit; color: inherit;
-  background: var(--bg); border: 1px solid var(--line-2); border-left: 3px solid var(--line-2);
-  border-radius: 4px; padding: 11px 13px; margin-bottom: 8px; cursor: pointer;
-  transition: border-color .15s, background-color .15s; }
-.card:hover { border-color: var(--fg-2); }
-.card.overdue { border-left-color: var(--seal); }
-.card.picked { background: var(--ctl-bg); border-color: var(--fg); }
-.card .what { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;
-  overflow: hidden; font-family: var(--serif); font-size: 14.5px; line-height: 1.45;
+  background: var(--bg); border: 1px solid var(--line-2); border-radius: 5px;
+  padding: 10px 12px; margin-bottom: 8px; cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0,0,0,.16), 0 1px 1px rgba(0,0,0,.10);
+  transition: border-color .15s, box-shadow .15s, transform .15s; }
+.card:last-child { margin-bottom: 0; }
+.card:hover { border-color: var(--fg-2); transform: translateY(-1px);
+  box-shadow: 0 3px 8px rgba(0,0,0,.20), 0 1px 2px rgba(0,0,0,.12); }
+.card.picked { border-color: var(--fg); box-shadow: 0 0 0 1px var(--fg); }
+/* the overdue stripe rides the card's leading edge, like a label in Jira */
+.card.overdue { border-left: 3px solid var(--seal); padding-left: 10px; }
+.card .what { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden; font-family: var(--serif); font-size: 14px; line-height: 1.4;
   color: var(--fg); text-wrap: pretty; }
-.card .meta { display: flex; flex-wrap: wrap; align-items: center; gap: 4px 7px; margin-top: 8px;
-  font-family: var(--mono); font-size: 10.5px; color: var(--fg-2); }
+.card .meta { display: flex; flex-wrap: wrap; align-items: center; gap: 5px 6px; margin-top: 9px;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-2); }
 .card .age { font-variant-numeric: tabular-nums; }
-.card .sep { color: var(--dim); }
-/* white on vermilion measures 4.62:1 in both themes; --seal-fg (3.68) and
-   near-black (3.88) both miss AA at this size */
-.card .due, #bdetail .dmeta .due { color: #fff; background: var(--seal);
-  border-radius: 2px; padding: 1px 5px; }
-.card .soft, #bdetail .soft { color: var(--fg-2); }
-.card .isle, #bdetail .isle { color: var(--warn); }
+/* chips, the way a tracker labels a card */
+.card .due, .card .isle { border-radius: 3px; padding: 2px 6px; letter-spacing: .02em; }
+.card .due { color: #fff; background: var(--seal); }
+.card .isle { color: var(--warn); border: 1px solid currentColor; }
+#bdetail .isle { color: var(--warn); }
+#bdetail .soft, .card .soft { color: var(--fg-2); }
 
-#bcount { flex: none; margin: 0; padding: 6px 22px 14px; font-family: var(--mono);
+#bcount { flex: none; margin: 0; padding: 8px 22px 14px; font-family: var(--mono);
   font-size: 10.5px; letter-spacing: .04em; color: var(--fg-2); }
-#bdetail { flex: none; display: flex; align-items: flex-start; gap: 20px;
-  padding: 15px 22px; background: var(--bg); border-top: 1px solid var(--line-2); }
-#bdetail .dtext { flex: 1; min-width: 0; }
-#bdetail .dbody { margin: 0; font-family: var(--serif); font-size: 15px; line-height: 1.5;
-  color: var(--fg); max-width: 68ch; max-height: 8.4em; overflow-y: auto; }
-#bdetail .dmeta { margin: 8px 0 0; font-family: var(--mono); font-size: 10.5px;
-  color: var(--fg-2); display: flex; flex-wrap: wrap; align-items: center; gap: 4px 8px; }
-#bdetail .dmeta b { font-family: var(--serif); font-size: 12.5px; font-weight: 400; color: var(--fg); }
-#bdetail .sep { color: var(--dim); }
-#bdetail .dacts { flex: none; display: flex; flex-wrap: wrap; gap: 8px; }
-#bdetail .cp.ok { border-color: var(--warn); color: var(--warn); }
+
+/* ── the card drawer — over the board, never squeezing it ── */
+#bdetail { position: absolute; top: 0; right: 0; bottom: 0; width: min(430px, 92vw);
+  z-index: 14; display: flex; flex-direction: column;
+  background: var(--bg); border-left: 1px solid var(--line-2);
+  box-shadow: -18px 0 40px rgba(0,0,0,.28); }
+#bdhead { flex: none; display: flex; align-items: center; gap: 12px;
+  padding: 15px 18px; border-bottom: 1px solid var(--line); }
+#bdhead .k { font-family: var(--mono); font-size: 9px; letter-spacing: .22em;
+  text-transform: uppercase; color: var(--kind); }
+#bdhead .colname { font-family: var(--mono); font-size: 10px; letter-spacing: .1em;
+  text-transform: uppercase; color: var(--fg-2); background: var(--ctl-bg);
+  border: 1px solid var(--line-2); border-radius: 10px; padding: 3px 9px; }
+#bdhead .x { margin-left: auto; width: 30px; padding: 0; justify-content: center; }
+#bdbody { flex: 1; min-height: 0; overflow-y: auto; padding: 16px 18px 20px; }
+#bdbody .dbody { margin: 0; font-family: var(--serif); font-size: 15px; line-height: 1.55;
+  color: var(--fg); white-space: pre-wrap; }
+#bdbody dl { display: grid; grid-template-columns: max-content 1fr; gap: 9px 16px;
+  margin: 20px 0 0; padding-top: 16px; border-top: 1px solid var(--line); }
+#bdbody dt { font-family: var(--mono); font-size: 9.5px; letter-spacing: .16em;
+  text-transform: uppercase; color: var(--fg-2); padding-top: 2px; }
+#bdbody dd { margin: 0; font-family: var(--serif); font-size: 13.5px; color: var(--fg); }
+#bdbody dd .mono { font-family: var(--mono); font-size: 11.5px; }
+#bdbody dd .due { color: #fff; background: var(--seal); border-radius: 3px; padding: 2px 6px;
+  font-family: var(--mono); font-size: 11px; }
+/* deliberate rows rather than a ragged wrap: the way in on top, the two
+   commands you copy underneath */
+#bdacts { flex: none; display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+  padding: 14px 18px; border-top: 1px solid var(--line); background: var(--ctl-bg); }
+#bdacts .btn { justify-content: center; }
+#bdacts .btn:first-child { grid-column: 1 / -1; }
+#bdacts .cp.ok { border-color: var(--warn); color: var(--warn); }
 
 @media (max-width: 720px) {
   #bbar { gap: 12px; }
   #bbar .bpick { margin-left: 0; width: 100%; }
-  #bdetail { flex-direction: column; gap: 12px; }
+  /* on a phone the drawer is the whole sheet — Jira does the same */
+  #bdetail { width: 100%; border-left: 0; }
 }
 
 /* ── motion, only for those who want it ────────────────── */


### PR DESCRIPTION
A third room next to the galaxy and the reader. The galaxy answers *where* a
thought sits, the reader *what it says*, the board *what is still owed*.

It renders the task board `docs/board.md` describes, over the same
`/graph.json` the other two rooms use: one board per initiative, a card's
column is the `status:<key>` tag on the task itself, columns in registry
order with the empties kept so the board doesn't flicker as it drains. A
status the registry doesn't know falls into the first column rather than
disappearing — the same rule the `board` verb applies. Checked against the
daemon: `1c-agent` → Open 50 / In Progress 0 / Done 11, matching `board
1c-agent` exactly.

**Read-only, deliberately.** `/graph.json` carries the `status:*` tags a
column is made of, but moving a card is `set_status` — a write the viz
endpoint does not have, and `viz.rs` is read-only by design. So the picked
card offers the command to copy rather than pretending to perform it.

## What it does

- **Rot, not recency.** Within a column: overdue first, then age, then
  isolation. Sorting by recency would bury exactly what this room exists to
  surface — 106 of the open tasks here have nothing linked to them, and the
  median one has been open over a month.
- **A card opens in a right drawer, over the board.** It carries the whole
  body (fetched once via `?bodies=true`), a labelled meta list, a link to
  the node it came out of, and the two commands. Escape closes the drawer
  first and the room only on the second press.
- **All initiatives at once**, with an owner chip per card; narrowing to one
  drops the chips. Opening the board follows the galaxy's project focus, so
  the two rooms agree on scope.
- **Filters that stack**: free text over name and body, plus four sieves —
  past due, no provenance, over a month, not done — each carrying its count.
  An empty result names what it filtered on and offers the way out.
- **The reader knows where it came from.** Opened from the board, its way out
  says "← board" and returns to the same initiative.

No topic filter: `topic:` is derived word-frequency, not a taxonomy — its
busiest values in a real vault are "блок", "новый", "документ" — so a topic
picker would mostly offer noise that free text finds better.

## Fixes outside the new room

Three defects older than this branch, all found while building on top of them:

- **The galaxy console let its controls fall off the right edge.** At 1280px
  it needed 1683px in the 1234 it had, so the theme switch and the whole
  time-lapse segment were unreachable. It wraps now.
- **The custom dropdown was not operable by keyboard.** A `<div tabindex=0>`
  with no role, no accessible name (its `<label for>` pointed at the
  `display:none` `<select>`), no `aria-expanded`, and no key handling — focus
  landed on it and there was no way to open it. Now a combobox over a listbox,
  named from its label, answering Enter / Space / ArrowDown / Escape. All four
  instances benefit.
- **Two contrast failures.** The kind label (`TASK BOARD`, `REASONING CHAIN`)
  was `--seal` on `--bg`: 2.88:1 at 9px. New `--kind` token, same vermilion
  family, 5.38:1 dark / 6.56:1 light — it fixes the reader's bar too. The
  dropdown's menu count was `--faint` on `--panel`, 2.51:1; now `--dim`, 5.0:1.

## Verification

- Every column count cross-checked against the `board` MCP verb on a live
  vault (1c-agent, zakup, q5, rag-system, kplus, kaeru, tooling).
- Contrast measured on a fresh load per theme — 13 pairs, all above 4.5:1.
  Measuring after an in-page theme toggle returns mid-transition values in
  this browser; the numbers above come from reloads.
- Keyboard: one tab stop per card plus a skip link past them; Escape
  progressive through drawer → room; focus enters the drawer and returns to
  the card it came from.
- 375 / 1100 / 1440 / 1800: no horizontal page scroll, cards readable, lanes
  scroll sideways on a phone.
- Board → drawer → reader → back → galaxy walked end to end. Console clean,
  `vite build` clean.

**Not verified:** live-resize reflow of the console. The embedded browser
changes the viewport without dispatching `resize` or firing ResizeObserver
(measured: 0 of each across an 1800→1100 change), so that path is covered by
reload-per-width instead. Nor a real screen reader — the ARIA conclusions are
from markup.

## Known gaps this does not close

- Customized column registries live in the `Board` node's `properties`, which
  `export_json.rs` does not export — so a board with custom columns renders
  with the built-in vocabulary, and a card in an unknown status shows under
  the first column. Adding `waiting` to an initiative is already possible from
  the chat and will diverge from what the browser shows until the export
  carries it.
- The middle column can only be filled from the chat.
