### PR TITLE
fix(mcp): read verbs accept a UUID id, not just a name

### DIFF
--- a/kaeru-mcp/src/params.rs
+++ b/kaeru-mcp/src/params.rs
@@ -541,9 +541,9 @@ pub struct CiteParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct BetweenParams {
-    /// First node name.
+    /// First node name (also accepts a UUIDv7 id).
     pub a: String,
-    /// Second node name.
+    /// Second node name (also accepts a UUIDv7 id).
     pub b: String,
     #[serde(default)]
     pub initiative: Option<String>,

--- a/kaeru-mcp/src/tools/lookup.rs
+++ b/kaeru-mcp/src/tools/lookup.rs
@@ -7,8 +7,7 @@ use rmcp::model::CallToolResult;
 
 use crate::utils::{
     AT_FULLTEXT_HINT_MANY, at_fulltext_hint, body_truncated, history_hint, recall_read_hint,
-    render_briefs, render_summary, resolve_name_or_id, text, to_mcp, was_revised,
-    with_initiative,
+    render_briefs, render_summary, resolve_name_or_id, text, to_mcp, was_revised, with_initiative,
 };
 
 pub fn recall(

--- a/kaeru-mcp/src/tools/lookup.rs
+++ b/kaeru-mcp/src/tools/lookup.rs
@@ -7,7 +7,7 @@ use rmcp::model::CallToolResult;
 
 use crate::utils::{
     AT_FULLTEXT_HINT_MANY, at_fulltext_hint, body_truncated, history_hint, recall_read_hint,
-    render_briefs, render_summary, resolve_name, resolve_name_or_id, text, to_mcp, was_revised,
+    render_briefs, render_summary, resolve_name_or_id, text, to_mcp, was_revised,
     with_initiative,
 };
 
@@ -56,7 +56,7 @@ pub fn trace(
     initiative: Option<&str>,
 ) -> Result<CallToolResult, McpError> {
     with_initiative(store, initiative, || {
-        let id = resolve_name(store, name)?;
+        let id = resolve_name_or_id(store, name)?;
         let ancestors = kaeru_core::recollect_provenance(store, &id).map_err(to_mcp)?;
         if ancestors.is_empty() {
             return Ok(text("(no provenance)"));
@@ -131,8 +131,8 @@ pub fn between(
     initiative: Option<&str>,
 ) -> Result<CallToolResult, McpError> {
     with_initiative(store, initiative, || {
-        let a_id = resolve_name(store, a)?;
-        let b_id = resolve_name(store, b)?;
+        let a_id = resolve_name_or_id(store, a)?;
+        let b_id = resolve_name_or_id(store, b)?;
         let edges = kaeru_core::between(store, &a_id, &b_id).map_err(to_mcp)?;
         if edges.is_empty() {
             return Ok(text(&format!("(no edges between {a} and {b})")));

--- a/kaeru-mcp/src/tools/temporal.rs
+++ b/kaeru-mcp/src/tools/temporal.rs
@@ -7,7 +7,7 @@ use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
 
 use crate::utils::{
-    fmt_ts, history_hint, history_read_version_hint, parse_when, resolve_name,
+    fmt_ts, history_hint, history_read_version_hint, parse_when, resolve_name_or_id,
     resolve_name_or_id_at, text, to_mcp, was_revised, with_initiative,
 };
 
@@ -50,7 +50,11 @@ pub fn history(
     initiative: Option<&str>,
 ) -> Result<CallToolResult, McpError> {
     with_initiative(store, initiative, || {
-        let id = resolve_name(store, name)?;
+        // Accept a raw UUID as well as a name — `NameScope` advertises
+        // polymorphic resolution, and `at` already honours it. Resolving
+        // name-only made `history <id>` fail with a misleading "no node
+        // named <id> at NOW".
+        let id = resolve_name_or_id(store, name)?;
         let revs = kaeru_core::history(store, &id).map_err(to_mcp)?;
         if revs.is_empty() {
             return Ok(text("(no history)"));
@@ -149,6 +153,29 @@ mod tests {
         assert!(
             hist_out.contains("read any version in full: `at d2 when="),
             "history points back to at's time-travel:\n{hist_out}"
+        );
+    }
+
+    /// `history` resolves a raw UUIDv7 id, not just a name — regression for
+    /// the resolver bug where it called the name-only `resolve_name` and a
+    /// `history <id>` call failed with a misleading "no node named <id> at
+    /// NOW". `at` already accepted ids; the two now agree.
+    #[test]
+    fn history_resolves_by_id() {
+        let store = store_t();
+        let id = kaeru_core::write_episode(
+            &store,
+            EpisodeKind::Observation,
+            Significance::Low,
+            "by-id",
+            "body",
+        )
+        .expect("write");
+
+        let out = text_of(history(&store, &id, Some("t")).expect("history by id resolves"));
+        assert!(
+            out.contains("by-id"),
+            "history addressed by id returns the node's timeline:\n{out}"
         );
     }
 


### PR DESCRIPTION
## Problem

`history`, `trace` and `between` resolved their target node through the
name-only `resolve_name`, while their `NameScope` params explicitly
advertise that a **UUIDv7 id** is also accepted. Passing an id therefore
failed with a misleading error:

```
no node named "01a02457-105f-7dc2-a960-47a4bb351a36" at NOW
```

`at` / `drill` / `forget` / `done` already used the polymorphic
`resolve_name_or_id` (and `resolve_name_or_id_at` for the time-travel
read), so the behaviour was inconsistent across otherwise-identical
read verbs. Reproduced deterministically: `at <id>` resolves, `history
<id>` does not, for the same node at the same moment.

## Fix

- `history`, `trace`, `between` now resolve through `resolve_name_or_id`.
- `BetweenParams` docs updated to state that a UUIDv7 id is accepted.
- Dropped the now-unused `resolve_name` import from `lookup.rs`.

Pure read path — no substrate/schema change.

## Test

Adds `history_resolves_by_id` (regression): a node addressed by its raw
id returns its timeline. Full `kaeru-mcp` suite green (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)