### PR TITLE
feat(mcp): link/unlink/reweight accept ids and resolve across initiatives

### DIFF
--- a/kaeru-mcp/src/params.rs
+++ b/kaeru-mcp/src/params.rs
@@ -230,9 +230,11 @@ pub struct JotParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LinkParams {
-    /// Source node name.
+    /// Source node name or id — resolved in the active initiative first,
+    /// then across all initiatives, so an edge may span initiatives.
     pub from: String,
-    /// Destination node name.
+    /// Destination node name or id — resolved in the active initiative
+    /// first, then across all initiatives.
     pub to: String,
     /// Edge type. Common values: `refers_to` (default), `causal`,
     /// `derived_from`, `contradicts`, `part_of`, `blocks`, `targets`,
@@ -258,9 +260,11 @@ fn default_edge_type() -> String {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ReweightParams {
-    /// Source node name or id.
+    /// Source node name or id — resolved in the active initiative first,
+    /// then across all initiatives.
     pub from: String,
-    /// Destination node name or id.
+    /// Destination node name or id — resolved in the active initiative
+    /// first, then across all initiatives.
     pub to: String,
     /// Edge type (default `refers_to`).
     #[serde(default = "default_edge_type")]

--- a/kaeru-mcp/src/server.rs
+++ b/kaeru-mcp/src/server.rs
@@ -238,7 +238,7 @@ impl KaeruServer {
     }
 
     #[tool(
-        description = "Create a typed edge between two named nodes. Edge type defaults to `refers_to`. Optional `weight` (0..1) or `strong=true` sets the connection strength used by knowledge chains — stronger links make shorter chain paths."
+        description = "Create a typed edge between two nodes (by name or id). Endpoints resolve in the active initiative first, then across all initiatives, so a link may span initiatives. Edge type defaults to `refers_to`. Optional `weight` (0..1) or `strong=true` sets the connection strength used by knowledge chains — stronger links make shorter chain paths."
     )]
     fn link(&self, Parameters(p): Parameters<LinkParams>) -> Result<CallToolResult, McpError> {
         tools::capture::link(

--- a/kaeru-mcp/src/tools/capture.rs
+++ b/kaeru-mcp/src/tools/capture.rs
@@ -220,7 +220,9 @@ mod tests {
     /// in the active initiative), so read it with the scope cleared.
     fn edge_count(store: &Store, a: &str, b: &str) -> usize {
         store
-            .scoped(None, |s| kaeru_core::between(s, &a.to_string(), &b.to_string()))
+            .scoped(None, |s| {
+                kaeru_core::between(s, &a.to_string(), &b.to_string())
+            })
             .expect("between")
             .len()
     }
@@ -235,8 +237,16 @@ mod tests {
         let a = seed(&store, "a", "node-a");
         let b = seed(&store, "b", "node-b");
 
-        link(&store, "node-a", "node-b", "refers_to", None, false, Some("a"))
-            .expect("cross-initiative link resolves");
+        link(
+            &store,
+            "node-a",
+            "node-b",
+            "refers_to",
+            None,
+            false,
+            Some("a"),
+        )
+        .expect("cross-initiative link resolves");
 
         assert_eq!(edge_count(&store, &a, &b), 1, "edge was created");
     }
@@ -248,8 +258,7 @@ mod tests {
         let a = seed(&store, "x", "src");
         let b = seed(&store, "x", "dst");
 
-        link(&store, &a, &b, "refers_to", None, false, Some("x"))
-            .expect("link by id resolves");
+        link(&store, &a, &b, "refers_to", None, false, Some("x")).expect("link by id resolves");
 
         assert_eq!(edge_count(&store, &a, &b), 1, "edge was created from ids");
     }

--- a/kaeru-mcp/src/tools/capture.rs
+++ b/kaeru-mcp/src/tools/capture.rs
@@ -14,8 +14,8 @@ use rmcp::model::CallToolResult;
 use crate::cloud_client::CloudClient;
 use crate::tools::cloud::push_to_cloud;
 use crate::utils::{
-    capture_result, parse_layer, parse_wants_shared, resolve_name, resolve_name_or_id, text,
-    to_mcp, with_initiative,
+    capture_result, parse_layer, parse_wants_shared, resolve_link_endpoint, text, to_mcp,
+    with_initiative,
 };
 
 /// When `want_share`, attempts to push the just-created node `id` to the
@@ -112,8 +112,8 @@ pub fn link(
 ) -> Result<CallToolResult, McpError> {
     with_initiative(store, initiative, || {
         let edge: EdgeType = edge_type_str.parse().map_err(to_mcp)?;
-        let from_id = resolve_name(store, from)?;
-        let to_id = resolve_name(store, to)?;
+        let from_id = resolve_link_endpoint(store, from)?;
+        let to_id = resolve_link_endpoint(store, to)?;
         // Plain link = 0.5 (a neutral association); `strong` = 1.0 (a key
         // reasoning link); explicit `weight` overrides. Weight is the
         // connection strength that drives chain shortest-paths.
@@ -139,8 +139,8 @@ pub fn unlink(
 ) -> Result<CallToolResult, McpError> {
     with_initiative(store, initiative, || {
         let edge: EdgeType = edge_type_str.parse().map_err(to_mcp)?;
-        let from_id = resolve_name(store, from)?;
-        let to_id = resolve_name(store, to)?;
+        let from_id = resolve_link_endpoint(store, from)?;
+        let to_id = resolve_link_endpoint(store, to)?;
         kaeru_core::unlink(store, &from_id, &to_id, edge).map_err(to_mcp)?;
         Ok(text(&format!(
             "unlinked: {from} -[{}]-> {to}",
@@ -162,8 +162,8 @@ pub fn reweight(
 ) -> Result<CallToolResult, McpError> {
     with_initiative(store, initiative, || {
         let edge: EdgeType = edge_type_str.parse().map_err(to_mcp)?;
-        let from_id = resolve_name_or_id(store, from)?;
-        let to_id = resolve_name_or_id(store, to)?;
+        let from_id = resolve_link_endpoint(store, from)?;
+        let to_id = resolve_link_endpoint(store, to)?;
         kaeru_core::set_edge_weight(store, &from_id, &to_id, edge, weight).map_err(to_mcp)?;
         Ok(text(&format!(
             "reweighted: {from} -[{}]-> {to} = {:.2}",
@@ -194,4 +194,63 @@ pub async fn cite(
     };
     maybe_share(store, cloud, &id, initiative, want_share, &mut msg).await?;
     Ok(capture_result(store, &id, initiative, &msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use kaeru_core::{EpisodeKind, Significance, Store};
+
+    use super::link;
+
+    /// Seeds a node under `initiative` and returns its id.
+    fn seed(store: &Store, initiative: &str, name: &str) -> String {
+        store.use_initiative(initiative);
+        kaeru_core::write_episode(
+            store,
+            EpisodeKind::Observation,
+            Significance::Low,
+            name,
+            "body",
+        )
+        .expect("write")
+    }
+
+    /// Counts edges between two ids cross-initiative — a cross-initiative
+    /// edge is invisible to a scoped `between` (which requires both endpoints
+    /// in the active initiative), so read it with the scope cleared.
+    fn edge_count(store: &Store, a: &str, b: &str) -> usize {
+        store
+            .scoped(None, |s| kaeru_core::between(s, &a.to_string(), &b.to_string()))
+            .expect("between")
+            .len()
+    }
+
+    /// An edge can join nodes living under different initiatives: scoped to
+    /// `a`, the source resolves in-scope while the destination (only in `b`)
+    /// resolves through the cross-initiative fallback. This is the friction
+    /// that used to force dropping the initiative scope to link at all.
+    #[test]
+    fn link_joins_nodes_across_initiatives() {
+        let store = Store::open_in_memory().expect("open");
+        let a = seed(&store, "a", "node-a");
+        let b = seed(&store, "b", "node-b");
+
+        link(&store, "node-a", "node-b", "refers_to", None, false, Some("a"))
+            .expect("cross-initiative link resolves");
+
+        assert_eq!(edge_count(&store, &a, &b), 1, "edge was created");
+    }
+
+    /// Endpoints may be raw UUIDv7 ids, not just names.
+    #[test]
+    fn link_accepts_ids() {
+        let store = Store::open_in_memory().expect("open");
+        let a = seed(&store, "x", "src");
+        let b = seed(&store, "x", "dst");
+
+        link(&store, &a, &b, "refers_to", None, false, Some("x"))
+            .expect("link by id resolves");
+
+        assert_eq!(edge_count(&store, &a, &b), 1, "edge was created from ids");
+    }
 }

--- a/kaeru-mcp/src/utils.rs
+++ b/kaeru-mcp/src/utils.rs
@@ -258,13 +258,42 @@ pub fn resolve_name(store: &Store, name: &str) -> Result<NodeId, McpError> {
         .ok_or_else(|| to_mcp(Error::NotFound(format!("no node named {name:?} at NOW"))))
 }
 
-/// UUIDv7 has 36 chars with dashes at fixed positions; cheap heuristic
-/// avoids a roundtrip when the caller already has an id.
+/// A UUIDv7 id is 36 chars with a `-` at index 8; this cheap shape check
+/// lets a resolver skip the name lookup when the caller already holds an id.
+pub fn looks_like_id(input: &str) -> bool {
+    input.len() == 36 && input.chars().nth(8) == Some('-')
+}
+
+/// Resolves a name at NOW, or passes a raw id straight through.
 pub fn resolve_name_or_id(store: &Store, input: &str) -> Result<NodeId, McpError> {
-    if input.len() == 36 && input.chars().nth(8) == Some('-') {
+    if looks_like_id(input) {
         return Ok(input.to_string());
     }
     resolve_name(store, input)
+}
+
+/// Resolves an edge endpoint for `link` / `unlink` / `reweight`: accepts a raw
+/// id, else resolves the name in the active initiative first and falls back to
+/// a cross-initiative lookup. An edge often joins nodes living under different
+/// initiatives — the scoped resolvers used by the read verbs would miss an
+/// endpoint outside the active scope, which is exactly the friction that made
+/// a cross-initiative `link` fail until the scope was dropped. Mirrors the
+/// global resolution `attach` already relies on. On a name collision the newest
+/// node wins, and a scoped match is preferred over the global fallback.
+pub fn resolve_link_endpoint(store: &Store, input: &str) -> Result<NodeId, McpError> {
+    if looks_like_id(input) {
+        return Ok(input.to_string());
+    }
+    if let Some(id) = kaeru_core::recall_id_by_name(store, input).map_err(to_mcp)? {
+        return Ok(id);
+    }
+    kaeru_core::recall_id_by_name_global(store, input)
+        .map_err(to_mcp)?
+        .ok_or_else(|| {
+            to_mcp(Error::NotFound(format!(
+                "no node named {input:?} at NOW (searched the active initiative, then all initiatives)"
+            )))
+        })
 }
 
 /// Like [`resolve_name_or_id`] but resolves a **name** as of `at_seconds`
@@ -276,7 +305,7 @@ pub fn resolve_name_or_id_at(
     input: &str,
     at_seconds: f64,
 ) -> Result<NodeId, McpError> {
-    if input.len() == 36 && input.chars().nth(8) == Some('-') {
+    if looks_like_id(input) {
         return Ok(input.to_string());
     }
     kaeru_core::recall_id_by_name_at(store, input, at_seconds)


### PR DESCRIPTION
## Problem

Edge endpoints in `link` / `unlink` / `reweight` resolved **by name only,
scoped to the active initiative** (`resolve_name`). Two consequences:

- Linking a node in one initiative to a node that lives only in another
  failed — you had to drop the initiative scope entirely to link at all.
- A raw UUIDv7 id was rejected, even though the read verbs accept ids.

Seen in the field: a decision node captured under one initiative could
not be `link`ed (scoped) to research nodes in another until the scope was
dropped.

## Fix

New `resolve_link_endpoint`:

1. passes a raw id straight through,
2. else resolves the name in the **active initiative** first,
3. else falls back to a **cross-initiative** lookup — the same global
   resolution `attach` already relies on.

So an edge may span initiatives. On a name collision the newest node
wins, with a scoped match preferred over the global fallback. `link`,
`unlink`, and `reweight` all route through it. `looks_like_id` is
factored out and shared with the existing `resolve_name_or_id*` helpers.

Param docs (`LinkParams`, `ReweightParams`) and the `link` tool
description updated to state id acceptance + cross-initiative resolution.

## Test

- `link_joins_nodes_across_initiatives` — source in `a`, destination only
  in `b`; scoped to `a`, the edge is created via the cross-initiative
  fallback.
- `link_accepts_ids` — endpoints given as raw ids.

Full `kaeru-mcp` suite green (22/22).

## Note

Independent of #61 (which made the *read* verbs `history`/`trace`/`between`
accept ids); this covers the *write* verbs and adds the cross-initiative
fallback. No substrate/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)