### PR TITLE
feat(core): scrub leaked tool-call wire-format at the capture boundary

### DIFF
--- a/kaeru-core/src/lib.rs
+++ b/kaeru-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod hygiene;
 mod migrate;
 pub mod mutate;
 pub mod recall;
+pub mod sanitize;
 pub mod session;
 pub mod store;
 
@@ -45,6 +46,7 @@ pub use mutate::{
     synthesise, unlink, update_hypothesis_status, upsert_edge, upsert_node, write_episode,
     write_episode_with_layer, write_task, write_task_with_layer,
 };
+pub use sanitize::strip_tool_call_markup;
 pub use recall::{
     BoardColumn, BoardStatus, BoardTask, BoardView, EdgeRow, FUZZY_RECALL_LIMIT_CAP, LayerBucket,
     LintReport, NodeBrief, NodeFull, ReflectionReport, SummaryView, between, board_view,

--- a/kaeru-core/src/lib.rs
+++ b/kaeru-core/src/lib.rs
@@ -46,7 +46,6 @@ pub use mutate::{
     synthesise, unlink, update_hypothesis_status, upsert_edge, upsert_node, write_episode,
     write_episode_with_layer, write_task, write_task_with_layer,
 };
-pub use sanitize::strip_tool_call_markup;
 pub use recall::{
     BoardColumn, BoardStatus, BoardTask, BoardView, EdgeRow, FUZZY_RECALL_LIMIT_CAP, LayerBucket,
     LintReport, NodeBrief, NodeFull, ReflectionReport, SummaryView, between, board_view,
@@ -58,6 +57,7 @@ pub use recall::{
     recollect_outcome, recollect_provenance, reflect, shortest_path, suggest_initiative,
     summary_view, tagged, under_review_pinned, walk,
 };
+pub use sanitize::strip_tool_call_markup;
 pub use session::{AwakenedContext, active_window, awake, pin, unpin};
 pub use store::Store;
 

--- a/kaeru-core/src/mutate/cite.rs
+++ b/kaeru-core/src/mutate/cite.rs
@@ -11,6 +11,7 @@ use super::{attach_node_to_initiative, build_body_tags, now_validity_seconds, ta
 use crate::errors::Result;
 use crate::graph::audit::write_audit;
 use crate::graph::{Layer, NodeId, new_node_id};
+use crate::sanitize::strip_tool_call_markup;
 use crate::store::Store;
 
 /// Creates an archival `Reference` node carrying `body` as its summary
@@ -35,6 +36,12 @@ pub fn cite_with_layer(
     body: &str,
     layer: Layer,
 ) -> Result<NodeId> {
+    // Scrub any leaked tool-call wire-format before it reaches the graph —
+    // a malformed caller can spill the invocation envelope into these strings.
+    let name_owned = strip_tool_call_markup(name).0;
+    let body_owned = strip_tool_call_markup(body).0;
+    let (name, body) = (name_owned.as_str(), body_owned.as_str());
+
     let id = new_node_id();
     let payload = match url {
         Some(u) => json!({ "url": u }),
@@ -65,4 +72,28 @@ pub fn cite_with_layer(
     attach_node_to_initiative(store, &id)?;
     write_audit(store.db_ref(), "cite", "system", &[id.clone()])?;
     Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cite_with_layer;
+    use crate::graph::{Layer, at};
+    use crate::store::Store;
+
+    /// A cite whose body carries leaked tool-call wire-format stores the
+    /// scrubbed content — the write boundary defends the graph regardless of
+    /// how the caller (an arbitrary LLM) formatted the call.
+    #[test]
+    fn cite_scrubs_leaked_markup_from_body() {
+        let store = Store::open_in_memory().expect("open");
+        store.use_initiative("t");
+        let dirty = "real content here.</body>\n<parameter name=\"initiative\">t";
+        let id =
+            cite_with_layer(&store, "clean-name", None, dirty, Layer::default()).expect("cite");
+
+        let snap = at(&store, &id, 9_999_999_999.0)
+            .expect("at")
+            .expect("snapshot");
+        assert_eq!(snap.body.as_deref(), Some("real content here."));
+    }
 }

--- a/kaeru-core/src/mutate/episode.rs
+++ b/kaeru-core/src/mutate/episode.rs
@@ -8,6 +8,7 @@ use super::{attach_node_to_initiative, build_body_tags, now_validity_seconds, ta
 use crate::errors::Result;
 use crate::graph::audit::write_audit;
 use crate::graph::{EpisodeKind, Layer, NodeId, Significance, new_node_id};
+use crate::sanitize::strip_tool_call_markup;
 use crate::store::Store;
 
 /// Writes an episode node and an audit_event for the operation.
@@ -32,6 +33,11 @@ pub fn write_episode_with_layer(
     body: &str,
     layer: Layer,
 ) -> Result<NodeId> {
+    // Scrub any leaked tool-call wire-format before it reaches the graph.
+    let name_owned = strip_tool_call_markup(name).0;
+    let body_owned = strip_tool_call_markup(body).0;
+    let (name, body) = (name_owned.as_str(), body_owned.as_str());
+
     let id = new_node_id();
 
     let mut params: BTreeMap<String, DataValue> = BTreeMap::new();
@@ -81,6 +87,11 @@ pub fn jot(store: &Store, body: &str) -> Result<NodeId> {
 
 /// Low-friction episode write with an explicit memory layer.
 pub fn jot_with_layer(store: &Store, body: &str, layer: Layer) -> Result<NodeId> {
+    // Scrub leaked tool-call wire-format; the auto-name derives from the
+    // cleaned body so garbage can't seep in through the name either.
+    let body_owned = strip_tool_call_markup(body).0;
+    let body = body_owned.as_str();
+
     let id = new_node_id();
     let name = derive_jot_name(body, &id);
 

--- a/kaeru-core/src/mutate/metabolism.rs
+++ b/kaeru-core/src/mutate/metabolism.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::errors::{Error, Result};
 use crate::graph::NodeId;
 use crate::graph::audit::write_audit;
+use crate::sanitize::strip_tool_call_markup;
 use crate::store::Store;
 
 /// Bi-temporal forget: retracts a node and every edge connected to it
@@ -75,6 +76,11 @@ pub fn forget(store: &Store, node_id: &NodeId) -> Result<()> {
 /// the new body, so stale topics don't accumulate across rewrites). Implemented as re-assert + retract through the bi-temporal
 /// substrate, so `history` shows both the old version and the new one.
 pub fn improve(store: &Store, node_id: &NodeId, new_name: &str, new_body: &str) -> Result<()> {
+    // Scrub leaked tool-call wire-format from the incoming revision.
+    let new_name_owned = strip_tool_call_markup(new_name).0;
+    let new_body_owned = strip_tool_call_markup(new_body).0;
+    let (new_name, new_body) = (new_name_owned.as_str(), new_body_owned.as_str());
+
     let current = read_node_now(store, node_id)?
         .ok_or_else(|| Error::NotFound(format!("node {node_id} not found at NOW")))?;
 

--- a/kaeru-core/src/sanitize.rs
+++ b/kaeru-core/src/sanitize.rs
@@ -80,7 +80,10 @@ mod tests {
         let dirty = "…max savings need a custom board, not a firmware toggle.</body>\n<parameter name=\"initiative\">rack";
         let (clean, stripped) = strip_tool_call_markup(dirty);
         assert!(stripped);
-        assert_eq!(clean, "…max savings need a custom board, not a firmware toggle.");
+        assert_eq!(
+            clean,
+            "…max savings need a custom board, not a firmware toggle."
+        );
     }
 
     /// A bare closing param tag with no orphan open tag before it.

--- a/kaeru-core/src/sanitize.rs
+++ b/kaeru-core/src/sanitize.rs
@@ -1,0 +1,127 @@
+//! Input hygiene for the capture boundary.
+//!
+//! kaeru is an MCP server: its callers are arbitrary LLMs, and a malformed
+//! tool call can spill the invocation envelope — the parameter open/close
+//! tags, an invoke wrapper — into a string argument (a node `name` or
+//! `body`). Stored verbatim, that garbage pollutes the graph and every
+//! downstream read. The server cannot control how a model formats a call,
+//! so it defends at the write boundary instead of trusting the input.
+//!
+//! [`strip_tool_call_markup`] removes that leaked envelope. It is
+//! deliberately **narrow**: it keys off the specific tool-call markers,
+//! never angle-bracket markup in general, so legitimate content — code
+//! (`Vec<u8>`), an XML/HTML snippet, even a literal `</body>` inside prose —
+//! passes through untouched. High precision, so it only fires on an actual
+//! leak, never on a body that merely contains `<...>`.
+
+/// Substrings unique to the tool-call invocation envelope. Chosen to match
+/// both the plain and the `antml:`-namespaced spellings via a single token
+/// (e.g. `parameter>` matches both `</parameter>` and its namespaced form),
+/// and kept specific (`parameter name=`, not a bare `parameter`) so ordinary
+/// prose about "a parameter" can't trip them. None of these appears in
+/// legitimate captured content.
+const ENVELOPE_MARKERS: &[&str] = &[
+    "parameter name=",
+    "parameter>",
+    "invoke name=",
+    "invoke>",
+    "function_calls>",
+    "function_results>",
+];
+
+/// Strips a leaked tool-call envelope from `input`, returning the cleaned
+/// string and `true` when anything was removed. Input with no envelope
+/// marker comes back unchanged (`false`).
+///
+/// The leak is always a *tail*: real content, then the spilled envelope
+/// (`…real text.</body>\n<parameter name="initiative">rack`). The cut is made
+/// at the tag that opens the earliest envelope marker, after also dropping an
+/// immediately preceding orphan closing tag (`</body>` / `</name>` — the
+/// close of the parameter the content belonged to) that would otherwise be
+/// left dangling. A standalone `</body>` in genuine prose is untouched: it is
+/// only removed when it directly abuts the envelope.
+pub fn strip_tool_call_markup(input: &str) -> (String, bool) {
+    let Some(marker_at) = ENVELOPE_MARKERS.iter().filter_map(|m| input.find(m)).min() else {
+        return (input.to_string(), false);
+    };
+
+    // Back up to the `<` that opens the marker's tag, so the whole tag
+    // (plain or namespaced) is dropped, not just its inner token.
+    let tag_start = input[..marker_at].rfind('<').unwrap_or(marker_at);
+    let mut head = input[..tag_start].trim_end();
+
+    // Drop a single orphan closing tag left from the leaked parameter, but
+    // only when it directly abuts the envelope — a `</body>` elsewhere in
+    // real prose never reaches this point.
+    if head.ends_with('>') {
+        if let Some(open) = head.rfind("</") {
+            let inner = &head[open + 2..head.len() - 1];
+            let simple_tag = !inner.is_empty()
+                && inner
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | ':'));
+            if simple_tag {
+                head = head[..open].trim_end();
+            }
+        }
+    }
+
+    (head.to_string(), true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_tool_call_markup;
+
+    /// The real-world leak: a spilled parameter envelope tail is removed,
+    /// including the orphan `</body>` that closed the leaked param.
+    #[test]
+    fn strips_the_observed_leak() {
+        let dirty = "…max savings need a custom board, not a firmware toggle.</body>\n<parameter name=\"initiative\">rack";
+        let (clean, stripped) = strip_tool_call_markup(dirty);
+        assert!(stripped);
+        assert_eq!(clean, "…max savings need a custom board, not a firmware toggle.");
+    }
+
+    /// A bare closing param tag with no orphan open tag before it.
+    #[test]
+    fn strips_a_trailing_close_tag() {
+        let (clean, stripped) = strip_tool_call_markup("the answer</parameter>");
+        assert!(stripped);
+        assert_eq!(clean, "the answer");
+    }
+
+    /// The namespaced spelling is caught by the same `parameter>` token —
+    /// assembled here so this file never emits the literal close tag.
+    #[test]
+    fn strips_the_namespaced_form() {
+        let dirty = concat!("keep this</antml", ":parameter>");
+        let (clean, stripped) = strip_tool_call_markup(dirty);
+        assert!(stripped);
+        assert_eq!(clean, "keep this");
+    }
+
+    /// Legitimate content with angle brackets is preserved — code, a
+    /// comparison, an HTML-ish tag — none of it is envelope wire-format.
+    #[test]
+    fn preserves_legitimate_markup() {
+        for s in [
+            "let v: Vec<u8> = go(); if a < b && c > d { ok }",
+            "the <body> element and its </body> close a page",
+            "config: <threshold>0.7</threshold> stays as-is",
+            "no markup here at all",
+        ] {
+            let (clean, stripped) = strip_tool_call_markup(s);
+            assert!(!stripped, "should not fire on: {s}");
+            assert_eq!(clean, s);
+        }
+    }
+
+    /// A body that is nothing but envelope collapses to empty, still flagged.
+    #[test]
+    fn wholly_envelope_becomes_empty() {
+        let (clean, stripped) = strip_tool_call_markup("<parameter name=\"body\">");
+        assert!(stripped);
+        assert_eq!(clean, "");
+    }
+}

--- a/kaeru-mcp/src/tools/capture.rs
+++ b/kaeru-mcp/src/tools/capture.rs
@@ -14,8 +14,8 @@ use rmcp::model::CallToolResult;
 use crate::cloud_client::CloudClient;
 use crate::tools::cloud::push_to_cloud;
 use crate::utils::{
-    capture_result, parse_layer, parse_wants_shared, resolve_name, resolve_name_or_id, text,
-    to_mcp, with_initiative,
+    capture_result, markup_strip_note, parse_layer, parse_wants_shared, resolve_name,
+    resolve_name_or_id, text, to_mcp, with_initiative,
 };
 
 /// When `want_share`, attempts to push the just-created node `id` to the
@@ -74,6 +74,9 @@ pub async fn episode(
         .map_err(to_mcp)
     })?;
     let mut msg = format!("wrote episode: {name} — {id}");
+    if let Some(note) = markup_strip_note(&[("name", name), ("body", body)]) {
+        msg.push_str(&note);
+    }
     maybe_share(store, cloud, &id, initiative, want_share, &mut msg).await?;
     Ok(capture_result(store, &id, initiative, &msg))
 }
@@ -97,6 +100,9 @@ pub async fn jot(
         .map(|b| b.name)
         .unwrap_or_default();
     let mut msg = format!("jotted: {name} — {id}");
+    if let Some(note) = markup_strip_note(&[("body", body)]) {
+        msg.push_str(&note);
+    }
     maybe_share(store, cloud, &id, initiative, want_share, &mut msg).await?;
     Ok(text(&msg))
 }
@@ -192,6 +198,9 @@ pub async fn cite(
         Some(u) => format!("cited: {name} ({u}) — {id}"),
         None => format!("cited: {name} — {id}"),
     };
+    if let Some(note) = markup_strip_note(&[("name", name), ("body", body)]) {
+        msg.push_str(&note);
+    }
     maybe_share(store, cloud, &id, initiative, want_share, &mut msg).await?;
     Ok(capture_result(store, &id, initiative, &msg))
 }

--- a/kaeru-mcp/src/tools/metabolism.rs
+++ b/kaeru-mcp/src/tools/metabolism.rs
@@ -6,7 +6,7 @@ use kaeru_core::{Error, Layer, Store, Visibility, get_visibility, set_layer as c
 use rmcp::ErrorData as McpError;
 use rmcp::model::CallToolResult;
 
-use crate::utils::{resolve_name_or_id, text, to_mcp, with_initiative};
+use crate::utils::{markup_strip_note, resolve_name_or_id, text, to_mcp, with_initiative};
 
 pub fn forget(
     store: &Store,
@@ -67,6 +67,18 @@ pub fn revise(
         let new_body = body.unwrap_or(&preserved_body);
         kaeru_core::improve(store, &id, new_name, new_body).map_err(to_mcp)?;
         let mut msg = format!("revised: {name} → {new_name}");
+        // Only the caller-supplied fields can carry leaked markup; the
+        // preserved body was read back from an already-clean node.
+        let mut supplied: Vec<(&str, &str)> = Vec::new();
+        if let Some(r) = rename {
+            supplied.push(("name", r));
+        }
+        if let Some(b) = body {
+            supplied.push(("body", b));
+        }
+        if let Some(note) = markup_strip_note(&supplied) {
+            msg.push_str(&note);
+        }
         if get_visibility(store, &id).map_err(to_mcp)? == Visibility::Shared {
             msg.push_str(
                 "\n⚠ cloud copy is stale — run `share` on this node to push the new version.",

--- a/kaeru-mcp/src/utils.rs
+++ b/kaeru-mcp/src/utils.rs
@@ -267,6 +267,26 @@ pub fn resolve_name_or_id(store: &Store, input: &str) -> Result<NodeId, McpError
     resolve_name(store, input)
 }
 
+/// Builds a one-line note when any capture field carried leaked tool-call
+/// wire-format that the core write path scrubbed. `fields` pairs a label with
+/// the raw input; the note names only the fields that were actually dirty, so
+/// a clean call gets `None` and no noise. The stripping itself happens in
+/// `kaeru-core`; this only mirrors the detection to tell the caller.
+pub fn markup_strip_note(fields: &[(&str, &str)]) -> Option<String> {
+    let dirty: Vec<&str> = fields
+        .iter()
+        .filter(|(_, raw)| kaeru_core::strip_tool_call_markup(raw).1)
+        .map(|(label, _)| *label)
+        .collect();
+    if dirty.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "\n(note: stripped leaked tool-call markup from {})",
+        dirty.join(" and ")
+    ))
+}
+
 /// Like [`resolve_name_or_id`] but resolves a **name** as of `at_seconds`
 /// rather than NOW, so a time-travel read (`at`) can target a node that has
 /// since been retracted. A raw id passes through untouched (the historical read


### PR DESCRIPTION
## Problem

kaeru is an MCP server; its callers are arbitrary LLMs and it has no
control over how a model formats a tool call. A malformed call can spill
the invocation envelope — the parameter open/close tags, an invoke
wrapper — into a string argument (`name` / `body`), and kaeru stored it
verbatim. Observed in the field: a `cite` body ended with
`…not a firmware toggle.</body>\n<parameter name="initiative">rack`, and
because the `initiative` collapsed into the body text the node also
landed un-scoped.

Treating whatever arrives as trusted is the server's bug, not the
caller's.

## Fix

New `kaeru_core::sanitize::strip_tool_call_markup` removes a leaked
envelope at the **write boundary**. It is deliberately **narrow** — keyed
to the specific tool-call markers (matching both plain and
`antml:`-namespaced spellings), never angle-bracket markup in general —
so legitimate content survives untouched: code (`Vec<u8>`), XML/HTML
snippets, even a literal `</body>` in prose. High precision: it only
fires on an actual leak.

Applied inside the write primitives — `cite`, `write_episode`, `jot`,
`improve` — so **every** adapter (MCP, rig, cloud ingest) gets clean
storage, not just one. The MCP capture/revise handlers add a
`(note: stripped leaked tool-call markup from …)` line so the caller is
told sanitization happened (policy: strip + flag, not silent, not reject).

## Tests

- Sanitizer units: observed leak, namespaced form, bare trailing close
  tag, wholly-envelope → empty, and **legitimate-markup preservation**
  (code / comparisons / HTML-ish tags pass through unchanged).
- `cite` wiring test: a dirty body is stored scrubbed.

kaeru-core 140 green, kaeru-mcp 20 green. Independent of #61/#62 (no
substrate/schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)