### PR TITLE
fix: a vendor tree that works off the machine that produced it

### DIFF
--- a/contrib/offline/fetch-vendor.sh
+++ b/contrib/offline/fetch-vendor.sh
@@ -63,7 +63,29 @@ fi
 rm -rf vendor
 mv "$tmp/vendor-repo/vendor" vendor
 mkdir -p .cargo
-cp "$tmp/vendor-repo/config.toml" .cargo/config.toml
+
+# The vendor repo's config.toml is `cargo vendor`'s own stdout, so its
+# `directory` is the absolute path the *publishing* machine vendored into —
+# a path that exists nowhere else. Point it at this checkout instead. Every
+# other line is copied through untouched, including the replacement stanza
+# for the pinned `graph_builder` git dependency, which is the reason the file
+# is captured rather than written by hand.
+#
+# Rewriting here rather than only at publish time is deliberate: a published
+# vendor tag is immutable, so this is also what makes already-released tags
+# usable.
+awk '/^directory = / { print "directory = \"vendor\""; next } { print }' \
+  "$tmp/vendor-repo/config.toml" > .cargo/config.toml
+
+# Make offline the config's own property rather than something every caller
+# has to remember to pass. `cargo vendor` does not print this stanza, so
+# without it `--offline` on the command line is the only thing standing
+# between a build and the network.
+cat >> .cargo/config.toml <<'CONFIG'
+
+[net]
+offline = true
+CONFIG
 
 crates="$(find vendor -mindepth 1 -maxdepth 1 -type d | wc -l)"
 size="$(du -sh vendor | cut -f1)"

--- a/contrib/offline/publish-vendor.sh
+++ b/contrib/offline/publish-vendor.sh
@@ -10,7 +10,8 @@
 #
 # What lands in the vendor repo, at the root:
 #   vendor/            every crate source `cargo vendor` produced
-#   config.toml        the source-replacement stanza cargo PRINTED for it
+#   config.toml        the source-replacement stanza cargo PRINTED for it,
+#                      with `directory` normalised to a relative path
 #   Cargo.lock         the lock this vendor tree corresponds to
 #   .gitattributes     `* -text` — see below, this one is not optional
 #
@@ -55,7 +56,15 @@ rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR/staging"
 # Capture the config cargo prints; it is the only correct source of the
 # replacement stanzas.
-cargo vendor --versioned-dirs "$WORKDIR/staging/vendor" > "$WORKDIR/staging/config.toml"
+cargo vendor --versioned-dirs "$WORKDIR/staging/vendor" > "$WORKDIR/staging/config.raw"
+
+# cargo prints `directory` as the absolute path it was handed — this machine's
+# temp dir, which exists nowhere else. Normalise it to what a consumer will
+# have. The git-dependency stanza, the reason this file is captured rather
+# than written by hand, passes through untouched.
+awk '/^directory = / { print "directory = \"vendor\""; next } { print }' \
+  "$WORKDIR/staging/config.raw" > "$WORKDIR/staging/config.toml"
+rm "$WORKDIR/staging/config.raw"
 
 cp Cargo.lock "$WORKDIR/staging/Cargo.lock"
 

--- a/docs/offline-build.md
+++ b/docs/offline-build.md
@@ -62,7 +62,8 @@ help.
 **macOS** — the Xcode command line tools carry all three.
 **Windows** — MSVC Build Tools with the "Desktop development with C++"
 workload, plus LLVM. `link.exe` from the same workload is what Rust itself
-needs on an `*-msvc` target.
+needs on an `*-msvc` target. `fetch-vendor.sh` is a shell script: run it from
+Git Bash, which ships with Git for Windows, not from `cmd` or PowerShell.
 
 ## Windows: the one that will bite you
 


### PR DESCRIPTION
## What is broken

The offline install shipped in v0.7.0 does not work on any machine except the one that published the vendor tag.

`fetch-vendor.sh` copies the vendor repo's `config.toml` through unchanged. That file is `cargo vendor`'s own stdout, so its `directory` is the absolute path the *publishing* machine vendored into:

```toml
[source.vendored-sources]
directory = "/tmp/kaeru-vendor-publish/staging/vendor"
```

Every build elsewhere dies in under a tenth of a second:

```
error: failed to load source for dependency `graph_builder`
Caused by: failed to read root of directory source:
  /tmp/kaeru-vendor-publish/staging/vendor
Caused by: No such file or directory (os error 2)
```

Root cause is `publish-vendor.sh:58` — `cargo vendor` prints `directory` as exactly the path it was handed, and it is handed `$WORKDIR/staging/vendor`.

## Why the fix goes on the install side

A published vendor tag is immutable by design; `publish-vendor.sh` refuses to move one. Fixing only the producer would therefore leave v0.7.0 broken until a version bump, over a defect that has nothing to do with the tree it vendored.

So `fetch-vendor.sh` now rewrites `directory` to point at the checkout it is installing into. Already-released tags become usable as-is. `publish-vendor.sh` is fixed too, so a future tag is not born wrong.

Everything else still comes from cargo's stdout — including the replacement stanza for the pinned `graph_builder` fork, which is the reason the file is captured rather than written by hand.

## Two smaller things on the same path

- **`[net] offline = true`.** `docs/offline-build.md` says the config sets it. It did not — `cargo vendor` never prints that stanza. Source replacement made the gap mostly academic (a missing crate fails with `no matching package` rather than being fetched), but the file did not say what the docs said it said. Now it does, and the guarantee no longer depends on the caller remembering `--offline`.
- **Git Bash.** `fetch-vendor.sh` is a shell script and the Windows section never said where to run it.

## Verification

Against the **published** v0.7.0 vendor tag, in Docker, from a fresh clone:

1. `git clone --depth 1 --branch v0.7.0` + `./contrib/offline/fetch-vendor.sh` in a networked container — 461 crates, 563 MB.
2. `cargo build --release -p kaeru-mcp` in a `--network none` container, empty `CARGO_HOME`, **no `--offline` flag**.

Result: cold build 3m41s, 38 MB binary, `CARGO_HOME` left at 68 KB with an empty `registry/` and no `git/` — nothing came from the network. The daemon starts and serves on `http://127.0.0.1:9876/mcp`.

The same sequence before this change fails immediately, on the path above.

Also confirmed while testing, unchanged by this PR and already documented correctly: `rustc` + a C compiler alone is not enough — without `libclang` the build stops at `zstd-sys` with `Unable to find libclang`. On Debian that is `build-essential` + `libclang-dev`.