### PR TITLE
fix: a published vendor tree names the publisher's own staging path

### DIFF
--- a/contrib/offline/fetch-vendor.sh
+++ b/contrib/offline/fetch-vendor.sh
@@ -11,7 +11,8 @@
 # It writes two things and touches nothing else:
 #   vendor/              the crate sources
 #   .cargo/config.toml   the source-replacement config, taken from the vendor
-#                        repo rather than written here
+#                        repo rather than written here, with only `directory`
+#                        repointed at the tree unpacked above
 #
 # Both are gitignored in the main repository — a vendor tree is fetched, never
 # committed alongside the source.
@@ -63,7 +64,28 @@ fi
 rm -rf vendor
 mv "$tmp/vendor-repo/vendor" vendor
 mkdir -p .cargo
-cp "$tmp/vendor-repo/config.toml" .cargo/config.toml
+
+# Everything in the published config is taken as cargo printed it, except
+# `directory`: point it at the vendor tree that was just unpacked here.
+#
+# Vendor trees published before this was fixed — v0.7.0 among them — carry the
+# publishing machine's absolute staging path, so copying the file verbatim
+# makes the build fail with
+#
+#   error: failed to read root of directory source: …/staging/vendor
+#
+# against a path the user never chose. Published tags are immutable by design
+# (publish-vendor.sh refuses to overwrite one), so rewriting it here is what
+# keeps those releases usable. For trees published since, this is a no-op.
+sed 's|^directory = .*|directory = "vendor"|' \
+  "$tmp/vendor-repo/config.toml" > .cargo/config.toml
+
+if ! grep -q '^directory = "vendor"$' .cargo/config.toml; then
+  echo "error: the vendored config has no 'directory' line to point at the" >&2
+  echo "       tree just unpacked — refusing to leave a config that would" >&2
+  echo "       silently build against crates.io instead." >&2
+  exit 1
+fi
 
 crates="$(find vendor -mindepth 1 -maxdepth 1 -type d | wc -l)"
 size="$(du -sh vendor | cut -f1)"

--- a/contrib/offline/publish-vendor.sh
+++ b/contrib/offline/publish-vendor.sh
@@ -17,7 +17,8 @@
 # `config.toml` is captured from cargo's own stdout rather than written by
 # hand. It carries the crates.io replacement *and* the stanza for the one git
 # dependency (`graph_builder`, a pinned fork). Hand-maintaining that is how it
-# silently drifts the next time a dependency changes.
+# silently drifts the next time a dependency changes. The single exception is
+# `directory`, which is rewritten below — see there for why.
 
 set -euo pipefail
 
@@ -56,6 +57,28 @@ mkdir -p "$WORKDIR/staging"
 # Capture the config cargo prints; it is the only correct source of the
 # replacement stanzas.
 cargo vendor --versioned-dirs "$WORKDIR/staging/vendor" > "$WORKDIR/staging/config.toml"
+
+# `directory` is the one field that must not be published verbatim. Cargo
+# echoes back the path it was handed, which is this machine's staging
+# directory — so shipping it as-is points every consumer at a /tmp path that
+# exists only here, and their build dies with
+#
+#   error: failed to read root of directory source: …/staging/vendor
+#
+# naming a directory they never chose. It has to be relative to the checkout
+# being built. Relative is also what makes the tree relocatable, which is the
+# entire point of fetching a vendor on one machine and building on another.
+# Everything else in the file stays exactly as cargo printed it.
+vendor_cfg="$WORKDIR/staging/config.toml"
+sed 's|^directory = .*|directory = "vendor"|' "$vendor_cfg" > "$vendor_cfg.tmp"
+mv "$vendor_cfg.tmp" "$vendor_cfg"
+
+if ! grep -q '^directory = "vendor"$' "$vendor_cfg"; then
+  echo "error: could not rewrite 'directory' in the vendored config; cargo's" >&2
+  echo "       output format may have changed. Publishing it unchanged would" >&2
+  echo "       bake this machine's path into the release." >&2
+  exit 1
+fi
 
 cp Cargo.lock "$WORKDIR/staging/Cargo.lock"
 


### PR DESCRIPTION
Fixes the second bug reported in #72: the offline build path does not currently work for anyone except the person who published the vendor tree.

## The problem

`cargo vendor` echoes `directory` back as whatever path it was handed. `publish-vendor.sh` hands it `"$WORKDIR/staging/vendor"`, so the `config.toml` committed to `kaeru-vendor` says:

```toml
[source.vendored-sources]
directory = "/tmp/kaeru-vendor-publish/staging/vendor"
```

and `fetch-vendor.sh` copies that verbatim into `.cargo/config.toml`. Every consumer gets a path that only ever existed on the publishing machine:

```
$ ./contrib/offline/fetch-vendor.sh v0.7.0     # succeeds, 580 MB fetched
$ cargo build --release --offline -p kaeru-mcp
error: failed to read root of directory source:
  /tmp/kaeru-vendor-publish/staging/vendor
No such file or directory (os error 2)
```

pointing at a directory the user never chose. `v0.7.0` is published this way, so `docs/offline-build.md` currently cannot be followed as written.

## The fix

Rewrite `directory` to the relative `"vendor"` in both scripts, leaving the rest of the file exactly as cargo printed it — the crates.io stanza and the `graph_builder` git stanza still come straight from cargo's stdout, which is what keeps them from drifting as the docs intend.

**Both sides are needed, not either one:**

- **`publish-vendor.sh`** — so tags published from here on are portable.
- **`fetch-vendor.sh`** — because a published vendor tree is immutable by design (`publish-vendor.sh` refuses to overwrite an existing tag), so rewriting on the consumer side is the only thing that makes the already-published `v0.7.0` usable. It is a no-op for correctly-published trees.

Relative is also what the README already promises — *"copy the whole directory to the machine that does not [have network], and build there"*. An absolute path cannot survive that move; `"vendor"` does.

Each rewrite is verified rather than assumed, so a future change to cargo's output format fails loudly instead of silently publishing a machine-specific path, or leaving behind a config that quietly resolves back to crates.io.

## Verification

Against the **already-published `v0.7.0` vendor tag**, from a clean checkout:

```
$ ./contrib/offline/fetch-vendor.sh v0.7.0
ready — 409 crates, 580M

$ cat .cargo/config.toml
[source.crates-io]
replace-with = "vendored-sources"

[source."git+https://github.com/lawless-m/graph?rev=790ef623533fa39574ddd11308e3abc3993c0994"]
git = "https://github.com/lawless-m/graph"
rev = "790ef623533fa39574ddd11308e3abc3993c0994"
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
```

then, in a container started with `--network none`:

```
$ cargo build --release --offline -p kaeru-mcp
    Finished `release` profile [optimized] target(s) in 2m 28s
```

The git-dependency stanza survives untouched, which was the point of capturing cargo's output in the first place.

Separately confirmed that cargo resolves the relative `directory` from the workspace root, and that a prepared tree still builds after being moved to a different path — the relocatability the README promises.

Note this is unrelated to the segfault in #72; it was just in the way of testing whether the vendored dependency tree was implicated in it. (It wasn't.)
