### PR TITLE
fix: the offline install stops on Windows before it fetches anything

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# `Cargo.lock` here has to stay byte-identical to the copy published in
+# kaeru-vendor: contrib/offline/fetch-vendor.sh compares the two with `cmp`
+# before it will install a vendor tree, because a vendor tree is only valid
+# for the exact lock it was built against.
+#
+# Git for Windows converts text files to CRLF on checkout by default. That
+# changes the bytes of this file and nothing else, so the comparison fails and
+# the offline install stops on a version mismatch that does not exist — the
+# lock is the right one, it just arrived with different line endings. The
+# vendor repository has carried `* -text` for this reason since it was
+# created; the guard was only ever on one side of the comparison.
+#
+# `text=auto eol=lf` rather than `-text`, so the normalisation also holds for
+# anything committed from a Windows machine, not just what is checked out.
+* text=auto eol=lf

--- a/contrib/offline/fetch-vendor.sh
+++ b/contrib/offline/fetch-vendor.sh
@@ -55,6 +55,17 @@ fi
 # terms of the actual mistake, rather than letting cargo say it later.
 if ! cmp -s Cargo.lock "$tmp/vendor-repo/Cargo.lock"; then
   echo "error: Cargo.lock here does not match the one $VERSION was vendored from." >&2
+  # Same content, different line endings is a different mistake with a
+  # different fix, and on Windows it is by far the likely one. Say which.
+  if cmp -s <(tr -d '\r' < Cargo.lock) \
+            <(tr -d '\r' < "$tmp/vendor-repo/Cargo.lock"); then
+    echo "       The two locks are the same apart from line endings, so this" >&2
+    echo "       checkout was converted to CRLF — Git for Windows does that by" >&2
+    echo "       default. Re-clone with core.autocrlf=false:" >&2
+    echo >&2
+    echo "         git -c core.autocrlf=false clone <url>" >&2
+    exit 1
+  fi
   echo "       The vendor tree is only valid for the exact lock it was built" >&2
   echo "       against. Either check out $VERSION, or publish a vendor for" >&2
   echo "       this lock with contrib/offline/publish-vendor.sh." >&2


### PR DESCRIPTION
## What happens

On a stock Windows install the offline path does not get as far as downloading a vendor tree:

```
error: Cargo.lock here does not match the one v0.7.0 was vendored from.
       The vendor tree is only valid for the exact lock it was built
       against. Either check out v0.7.0, or publish a vendor for
       this lock with contrib/offline/publish-vendor.sh.
```

The lock is the right one. Git for Windows converts text files to CRLF on checkout by default, and this repository has no `.gitattributes` to say otherwise — so `Cargo.lock` here arrives with different bytes than the copy published in `kaeru-vendor`, which *does* carry `* -text` and therefore keeps LF. `cmp -s` compares bytes, and stops.

The guard that exists for exactly this failure mode was only ever on one side of the comparison.

Observed on a `windows-latest` runner with rustc 1.98 `x86_64-pc-windows-msvc`, Visual Studio Enterprise 2026 and LLVM present — nothing to do with the toolchain:

```
kaeru/Cargo.lock:        ASCII text, with CRLF line terminators
kaeru-vendor/Cargo.lock: ASCII text
cmp: differ: char 50, line 1
```

Line 1 of `Cargo.lock` is 49 characters, so the first differing byte is the line terminator itself.

## The change

**`.gitattributes`** — `* text=auto eol=lf`. Mirrors the vendor repo's intent, but normalises rather than just refusing conversion, so the rule also covers anything committed from a Windows machine.

**A better error message.** "Either check out v0.7.0, or publish a vendor for this lock" is unhelpful advice for this case: the user *has* checked out v0.7.0, and cannot publish a vendor tree. The script now notices that the two locks are identical apart from line endings and says so:

```
error: Cargo.lock here does not match the one v0.7.0 was vendored from.
       The two locks are the same apart from line endings, so this
       checkout was converted to CRLF — Git for Windows does that by
       default. Re-clone with core.autocrlf=false:

         git -c core.autocrlf=false clone <url>
```

That matters beyond politeness: `.gitattributes` only takes effect on a fresh clone, so anyone who already has a converted checkout needs the remedy, not the file.

## Verification

A/B on one `windows-latest` runner, `core.autocrlf` left at the Windows default in both arms — one variable: [run 33157178305](https://github.com/1Croydan1/kaeru/actions/runs/33157178305)

```
BEFORE (upstream main):  Cargo.lock: ASCII text, with CRLF line terminators  → failure
AFTER  (this branch):    Cargo.lock: ASCII text                              → success
                         ready — 461 crates, 554M
```

The new message was exercised separately, by converting `Cargo.lock` to CRLF in a Linux container and running the script against it.

## Context: the rest of the Windows path is fine

From an earlier run on the same runner ([33155575435](https://github.com/1Croydan1/kaeru/actions/runs/33155575435)), with the conversion turned off manually, everything downstream of this already worked:

- `fetch-vendor.sh` from Git Bash — fine
- `cargo build --release -p kaeru-mcp`, **no `--offline` flag**, empty `CARGO_HOME` — 15m20s, `kaeru-mcp.exe` 31.8 MB, `git` cache never created
- daemon starts, vault at `%LOCALAPPDATA%\ai.lamantin.kaeru`, serving on `127.0.0.1:9876`

Linux is unaffected and passes end to end: in a `--network none` container with an empty `CARGO_HOME` and no `--offline` flag, 3m23s, 38 MB binary, daemon serving.

So this is the one thing between a Windows user and an offline build.