### PR TITLE
bench: a suite that measures whether agents reach for memory at all

### DIFF
--- a/benchmarks/tool-usage/CATALOG.md
+++ b/benchmarks/tool-usage/CATALOG.md
@@ -1,0 +1,85 @@
+# Situation catalogue
+
+Twenty-seven situations, each observed in real sessions. `mode` is `silent` when
+the prompt does not mention memory — the agent must consult it unprompted.
+
+Field evidence is quoted from the user's own words at the moment they had to stop
+the agent. Identifying details are removed; the structure is unchanged.
+
+---
+
+## A. Asked, and got the wrong answer
+
+*The costliest mechanism. In every case below the agent had already made memory
+calls — 15 to 143 of them — before the user intervened. Counting calls scores these
+sessions as exemplary; they were failures.*
+
+| id | situation | must be recoverable after | mode | field evidence |
+|---|---|---|---|---|
+| `A1-stale-method` | Two methods for the same task exist; the newer one says in prose that it replaces the older. Agent must use the current one. | the current method, and no use of the superseded one | silent | 62 calls, then: *"you seem to have forgotten how we take screenshots now — look in kaeru, we have a **current** method"* |
+| `A2-unreachable-core` | A rule was stored with `layer=core` but no initiative, so it loads in no session (#81). Agent works inside an initiative. | the rule applied, or an explicit report that memory holds nothing on it | silent | 85 calls and two `awake`s, then: *"you forgot **again**… put it in core already, you're driving me mad"* |
+| `A3-fragmented-project` | One project's knowledge is spread across several initiatives; the needed fact is in a sibling of the one being worked in. | the fact found across the boundary, not recreated | silent | *"look in kaeru, in some initiative"* — user had to name the search space |
+| `A4-name-misremembered` | The agent recalls a node name imprecisely; exact lookup fails. | the node found by search rather than abandoned or duplicated | silent | 26 name-misses in four days; agents retry guesses instead of searching |
+| `A5-current-vs-history` | Several dated versions of a procedure exist; the question is about the one in force now. | the newest version, with the older ones not presented as current | explicit | *"you can look in kaeru for the **current** information on how we uploaded"* |
+| `A6-answer-in-own-artifact` | The answer is in a document the project already produced, not in a search index. | the answer taken from the existing artifact | silent | *"why are you searching — the flows are described in our own lesson"* |
+| `A7-duplicate-before-write` | About to store something already stored under a different name. | one node, not two; existing one found first | silent | duplicate hub nodes observed in the live graph |
+
+## B. A rule was stated in conversation and never captured
+
+*The most frequent mechanism — 12 interruptions. A constraint is spoken once, holds
+for weeks, and nothing writes it down. The next session breaks it again.*
+
+| id | situation | must be recoverable after | mode | field evidence |
+|---|---|---|---|---|
+| `B1-constraint-spoken` | User states a hard constraint mid-work ("never set X, only Y"). Session ends. | the constraint stored as a rule, scoped so it loads in this project | explicit | *"we absolutely must not set medium, only low"* — said twice in one day, in two sessions; memory held nothing |
+| `B2-constraint-after-compaction` | Same, but the session is compacted before the work continues. | the constraint survives compaction via memory, not via context | silent | both sessions above began with a context compaction |
+| `B3-scope-limit` | User narrows scope ("research only, no code changes"). | the limit respected for the rest of the arc | explicit | *"on the icons, research only for now, no code changes"* |
+| `B4-precondition` | User states a precondition for a routine action ("pull all branches before opening PRs"). | precondition applied next time the action comes up | silent | *"before making PRs, pull the current branches — we might be working on a stale one"* |
+| `B5-write-restriction` | User restricts what may be written **to memory** ("don't record the money side"). | the restriction honoured, and itself remembered | explicit | *"just don't write about the money in kaeru"* |
+| `B6-do-not-reopen` | User closes a topic ("don't raise this again"). | the topic not reopened in later sessions | silent | *"don't worry about that bot, I checked it works — don't raise this for now"* |
+
+## C. Memory was never consulted
+
+*Eight interruptions, five with zero memory calls before the user intervened.*
+
+| id | situation | must be recoverable after | mode | field evidence |
+|---|---|---|---|---|
+| `C1-reentry-cold` | Returning to a project after a break, with open debts waiting. | debts named before work starts | silent | *"first do awake in kaeru, then continue"* |
+| `C2-deployment-target` | A fact about where things live (server, environment) is in memory; agent assumes instead. | the stored target used | silent | zero calls, then: *"what are you doing — that's deployed on a different server, look in kaeru"* |
+| `C3-prior-decision` | A settled decision exists; agent proposes reopening it. | the decision found and respected | silent | *"no, we're definitely not changing the stack"* — zero calls |
+| `C4-roadmap-not-written` | A plan is agreed in conversation; nothing records it. | plan stored and usable next session | explicit | *"did you write the roadmap into memory so we can follow it?"* |
+
+## D. Capture dispatch — the verb matched to the epistemic status
+
+*Not interruptions but graph damage: the wrong verb leaves the next session unable
+to tell settled from open.*
+
+| id | situation | must be recoverable after | mode | field evidence |
+|---|---|---|---|---|
+| `D1-retrospective-verdict` | A suspicion was checked before memory was reached; the verdict is already known. | a hypothesis carrying its verdict and evidence | explicit | 13 of 23 real claims arrived with the answer already known; several still sit open with "REFUTED" in the prose |
+| `D2-partial-verdict` | The check ran and did not decide. | the third verdict recorded, not prose | explicit | "VERDICT: PARTIAL" written into bodies, status left open |
+| `D3-arc-closed` | A line of work ends in verified delivery. | the outcome promoted to the archival tier | silent | five-episode arc ending "deployed and verified in production" — zero consolidation |
+| `D4-settled-doc` | A durable document is produced (spec, rule, glossary). | stored as a reference, not a journal entry | explicit | "capturing everything as episode" — 545 episodes against 4 outcomes |
+| `D5-trail-worth-saving` | Work runs from observation to decision across sessions. | the trail saved and readable later | silent | 22 chains written, zero read in the whole history |
+
+## E. Debts and lifecycle
+
+| id | situation | must be recoverable after | mode | field evidence |
+|---|---|---|---|---|
+| `E1-overdue-task` | A task with a deadline passed while work continued elsewhere in the same project. | the overdue task surfaced before new work | silent | a task eight days overdue while the agent closed a neighbouring one |
+| `E2-task-closed` | Work completing a stored task is finished. | the task moved out of open | silent | 69 tasks created against 14 closed |
+| `E3-contradiction` | New evidence contradicts a stored fact. | the conflict marked, not silently duplicated | silent | agent wrote "refuted-…" as a fresh episode, left the original unmarked |
+| `E4-archived-needed` | The needed knowledge was demoted to a cold layer. | brought back into view | explicit | 141 demotions to cold, zero reads back |
+| `E5-team-tier` | Working in a shared initiative where the team has published relevant nodes. | cloud tier consulted before answering locally | silent | 23 of 24 cloud sessions happened only because the user asked |
+
+---
+
+## Proportions
+
+The suite follows the corpus, not a feature list. Group A is the smallest by count
+and the largest by cost, so it carries the most cases per situation. Group B is the
+most frequent mechanism in the field and is under-served by every existing memory
+benchmark, because it requires a prompt in which nobody says a rule was stated.
+
+Eighteen of twenty-seven are `silent`. That ratio is deliberate: in the corpus, the
+prompts that preceded the most expensive failures were ordinary work requests.

--- a/benchmarks/tool-usage/DESIGN.md
+++ b/benchmarks/tool-usage/DESIGN.md
@@ -1,0 +1,195 @@
+# Tool-usage suite — design
+
+> Sibling to `../agent-memory/`, measuring the other axis. That suite asks
+> **can memory produce the right answer** when the facts are messy. This one asks
+> **does a working agent reach for memory at all, and does it get back the current
+> answer** — in situations where a real user had to stop the agent and say so.
+
+## Why this suite exists
+
+Every case here is taken from a session that actually happened, and every one of
+them cost something: an interrupted response, a repeated instruction, work redone.
+They come from two passes over one vault's full history (13,110 session files,
+June–September 2026): an inventory of tool calls, and a classification of all 136
+unique interrupted responses by what the user had to say afterwards.
+
+That second pass is what shaped this suite. The failures cluster into three
+mechanisms, and the biggest is not the one anybody predicted:
+
+| mechanism | share of memory-related interruptions | what it looks like |
+|---|---|---|
+| **asked and got the wrong answer** | 8 cases, the costliest | agent had made 15–143 memory calls before the user stepped in |
+| **rule stated in conversation, never captured** | 12 cases, the most frequent | "don't upload until it's fixed", "pull the branches before opening PRs" |
+| **never asked memory at all** | 8 cases, 5 with zero calls | "use kaeru, friend", "did you even use kaeru?" |
+
+The first mechanism is why this suite cannot be a retrieval benchmark. In the worst
+case the agent made **143** memory calls and still used a superseded method, because
+the current one was unreachable from the initiative it was working in. Counting
+calls would have scored that session as exemplary.
+
+## The measurement problem, and how this suite solves it
+
+A benchmark that prescribes a verb sequence measures obedience, not memory: if two
+reasonable storage strategies exist and the agent picks the second, that is not a
+failure. But "just grade the final answer" throws away the thing we actually need
+to know — whether the agent *used its instrument*.
+
+The resolution is in how an expectation is written:
+
+- **Never**: "the agent must call `claim --verdict refuted`".
+- **Instead**: "after this session, memory must hold a hypothesis whose status is
+  refuted, attached to its evidence" — reachable by any of three verb paths, all
+  scored equal.
+- **Failure** is a state, not a missing call: a bare `episode` whose body says
+  "refuted" leaves the next session unable to tell a closed question from an open
+  one. That is what actually happened in the logs, repeatedly.
+
+So every expectation in this suite is a property of **the memory left behind and of
+what the next session can recover from it**. The tool-call trace is recorded, but as
+diagnosis ("which path did it take"), never as the grade.
+
+## Case anatomy
+
+Each case is a directory:
+
+```
+cases/<case-id>/
+├── case.yaml       # situation, prompts, expectations, trap, baseline
+└── fixture.yaml    # the memory state the agent wakes up to
+```
+
+**`fixture.yaml`** declares nodes, edges, layers, tiers, tasks and chains to
+create before the run — including, deliberately, the stale and competing material.
+A case whose fixture is clean tests nothing that fails in practice.
+
+**`case.yaml`** carries:
+
+- `prompt` — an ordinary work request, phrased as the user actually phrases them.
+- `mode` — `explicit` (the prompt mentions memory) or **`silent`** (it does not).
+- `expect.memory_after` — what must be recoverable, with `any_of` paths where
+  several storage strategies are legitimate.
+- `expect.behaviour` — what the answer or the work must show.
+- `fail_if` — the specific wrong outcome observed in the field.
+- `trap` — the deliberate hazard, named.
+- `baseline` — what the agent actually did when this happened, with the date and
+  the user's own words. This is the part no invented case can have.
+
+### `silent` mode is half the suite
+
+The failures that hurt most were not questions about memory. The user asked for
+ordinary work; the agent, not knowing what memory held, did it wrong. So half the
+cases never mention memory in the prompt — the fixture contains a rule or a current
+method, and the only way to succeed is to consult it unprompted. A suite where every
+prompt says "look in memory" measures retrieval under laboratory conditions and
+would have missed every one of the eight most expensive failures in the corpus.
+
+## Scoring
+
+Per case, three independent outcomes:
+
+1. **Outcome** — did `memory_after` hold and `fail_if` stay clear? Pass/fail.
+2. **Currency** — of the facts the agent used, how many were the current version
+   rather than a superseded one? A confident stale answer scores **below** silence:
+   in the field it is what produced the interruptions.
+3. **Cost** — calls made before the answer was reached; and for `silent` cases,
+   whether memory was consulted before the work started or only after being told.
+
+Agents are stochastic, so a case is run N times and scored as a rate, not a verdict.
+Fixed model and fixed fixture keep everything else deterministic; the fixture build
+is pure I/O and reproducible byte-for-byte.
+
+**What is deliberately not a metric:** the number of distinct verbs used. Under the
+enrichment model in #79, knowledge delivered inside another answer is a *better*
+outcome than a call — zero calls with the right result is a success, and a suite
+that rewards verb variety would push the product the wrong way.
+
+## Fixture requirements — learned from the first pilot
+
+Two cases (A1, A2) were run against live fixtures before the rest were written.
+Both "passed", and the pilot's value was in showing that one of those passes was
+meaningless. Three rules follow, and they bind every case built from here on.
+
+### 1. A case must be unpassable without the mechanism it tests
+
+A2 was supposed to prove that an unreachable rule (#81) changes behaviour. The
+agent did the right thing — it refused to publish — but the trace shows it never
+found the rule and never looked for one. Three other paths led to the same
+outcome: a sibling node in the fixture spelled out the constraint ("three reviewer
+comments are still open"), a second one warned that re-uploading loses comment
+anchors, and the agent's own standing policy is to confirm before publishing
+anywhere. It said so itself: *"the note in memory describes the procedure but is
+not permission to upload."*
+
+A case whose expected behaviour has other sufficient causes measures nothing. So:
+
+- **the rule must be arbitrary, not inferable** — "never re-upload whole, always
+  patch blocks" is checkable and unguessable; "don't publish with open comments"
+  is common sense and will be honoured for free;
+- **no other fixture node may restate it**, in whole or in part;
+- **the action must be routine**, not one that trips built-in caution. Publishing,
+  deleting and spending money are all confirmed by default, so they cannot be
+  used to detect whether memory was consulted.
+
+Before a case is accepted, write down every path to the expected behaviour. If any
+path avoids the mechanism, the case is not yet a test.
+
+### 2. A fixture must reproduce scale, not only structure
+
+A1 recreated the field failure faithfully in shape — a current method, two live
+predecessors, supersession stated only in prose — and the agent got it right on the
+first search, immediately naming the supersession it read in the text. In the field
+the same agent had made 62 calls and still used the stale method.
+
+The difference is size. Four nodes, with a `refers_to` edge pointing straight at the
+current method and nothing else competing, is not the graph where this fails. The
+failure needs a working set where the right node does not surface first: dozens of
+nodes, several plausible hits per query, and the current one **not** the newest.
+
+Fixtures therefore need a `noise` section — bulk nodes that share vocabulary with
+the target — and cases like A1 need the target buried rather than adjacent. A case
+that passes on a four-node fixture has proved nothing about a four-hundred-node one.
+
+### 3. Failure criteria are deviations, not lists of wrong answers
+
+A2's rewritten run produced neither the correct format (TSV) nor the one the case
+warned against (CSV): it wrote a Markdown table, named by ISO week, with a page of
+reasoning for why that naming was best. Two of three `fail_if` clauses named
+specific wrong choices and missed it entirely.
+
+Plausible-and-wrong is the *normal* shape of this failure, not an edge case — in
+the field the agent's stale screenshot method was equally well argued. So failure
+must be written as **deviation from the convention** ("the file is not TSV", "the
+name does not match the pattern"), never as an enumeration of anticipated mistakes.
+The corollary for grading: an answer's confidence and reasoning quality say nothing
+about whether the convention was consulted, and must not be read as evidence that
+it was.
+
+### 4. Runs must be isolated
+
+The A1 agent wrote its own node into the fixture and linked it — correct behaviour,
+and it left the fixture different from how it started. Any second run would begin
+from a mutated state. A runner must therefore build the fixture into a scratch vault
+per run and discard it afterwards; never against a working vault. During this pilot
+the cleanup was manual, which does not scale past a handful of runs.
+
+## Coverage
+
+Twenty-seven situations, in `CATALOG.md`, each with the field evidence behind it.
+They are grouped by mechanism, and the proportions follow the corpus rather than a
+feature list — so, for instance, retrospective capture (the verdict is already known
+when memory is reached) outweighs the prospective claim→test→verdict cycle, because
+that is the ratio observed in real sessions: 13 of 23 claims arrived with the answer
+already in hand.
+
+## Relationship to the golden dataset (#80)
+
+`#80` builds cases as **Layer → Fill → Task**: give the agent material, let it store,
+then ask something answerable only from memory. That format measures storage and
+recall quality well, and this suite does not duplicate it.
+
+It cannot, however, express the two largest mechanisms above: in it, knowledge is
+always deliberately filed and then explicitly asked for. "Asked and got a stale
+answer" needs a fixture with a live predecessor; "rule never captured" needs a prompt
+where nothing tells the agent that a rule was even stated. Both are what `silent`
+mode and hand-built fixtures are for. The suites are complementary and should share
+a fixture format.

--- a/benchmarks/tool-usage/README.md
+++ b/benchmarks/tool-usage/README.md
@@ -1,0 +1,59 @@
+# tool-usage — does the agent reach for memory, and get the current answer?
+
+A regression instrument for the curator API. Sibling to `../agent-memory/`:
+that suite asks whether memory can produce the right answer; this one asks
+whether a working agent uses memory at all, and whether what comes back is the
+version in force.
+
+- **[DESIGN.md](DESIGN.md)** — method, why expectations are states rather than
+  verb sequences, scoring, and how this differs from the golden dataset (#80).
+- **[CATALOG.md](CATALOG.md)** — 27 situations, grouped by failure mechanism,
+  each with the field evidence behind it.
+- **[cases/](cases/)** — worked cases: a fixture, a prompt, and expectations.
+
+## Status
+
+**All 27 catalogued situations are built.** The suite is a dataset; no runner
+yet — see DESIGN.md for what a runner must compute.
+
+| group | cases | what the group isolates |
+|---|---|---|
+| **A · asked, got the wrong answer** | A1 A2 A3 A4 A5 A6 A7 | the costliest mechanism: memory was consulted and returned the wrong thing — stale versions, unreachable nodes, sibling initiatives, misremembered names, answers living in artifacts |
+| **B · rule stated, never captured** | B1 B2 B3 B4 B5 B6 | the most frequent mechanism: a constraint spoken once, holding for weeks, that nothing writes down |
+| **C · memory never consulted** | C1 C2 C3 C4 | zero-call failures: cold re-entry, assumed topology, reopened decisions, unrecorded plans |
+| **D · capture dispatch** | D1 D2 D3 D4 D5 | the verb matched to epistemic status, so the next session can tell settled from open |
+| **E · debts and lifecycle** | E1 E2 E3 E4 E5 | overdue work, unclosed tasks, unmarked contradictions, cold knowledge, the team tier |
+
+**Modes.** 13 single-turn `silent`, 6 `explicit`, 8 multi-turn (a rule is stated
+in one session and must survive into the next). Every case carries a `baseline`
+recording what actually happened in the field, and every fixture pulls a noise
+bank so the target does not sit on the surface.
+
+**Regression guards.** Individual cases are pinned to known defects and fixes, so
+a change that breaks one names itself: A2 → #81 (fails while open, by design),
+D2 → the `inconclusive` verdict added in v0.7.0, D5 → #71 chain membership across
+promotion, C1 and E1 → the awake read-back sections, A5 → structural vs prose
+supersession (paired with variant A5b to measure what the edges buy).
+
+**Piloted so far:** A1 and A2 only, on 2026-09-01. The remaining 25 are written to
+the post-pilot template but have not been run. Expect some to need the same
+treatment A2 did — the pilot's first lesson was that a case can pass without
+touching its mechanism, and only a run reveals it.
+
+## Where the cases come from
+
+Two audits of one vault's complete history — 13,110 session files, June to
+September 2026. The first inventoried every `mcp__kaeru__*` call and every
+error. The second classified all 136 unique interrupted responses by what the
+user said after stopping the agent.
+
+That classification is why the suite is shaped the way it is. The most
+expensive failure was not "the agent never asked memory" — in the worst case it
+had made **143** memory calls before the user intervened, and still acted on a
+superseded method. Any metric built on call counts would have scored that
+session as exemplary. So the cases measure what was left in memory and whether
+the answer used was current, never which verbs were called.
+
+Eighteen of the twenty-seven situations are `silent`: the prompt is an ordinary
+work request that never mentions memory, because that is how the real failures
+arrived.

--- a/benchmarks/tool-usage/cases/A1-stale-method/case.yaml
+++ b/benchmarks/tool-usage/cases/A1-stale-method/case.yaml
@@ -1,0 +1,85 @@
+id: A1-stale-method
+situation: A2 in CATALOG.md — asked, and got the wrong answer
+mechanism: relevance
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Take the four missing frames for the setup guide — the connection dialog,
+  the credential panel, the run history and the error state. I'm working on
+  the other screen, so just get them done.
+
+# The prompt never mentions memory. It does contain the tell that made this
+# expensive in the field: the user is using the machine at the same time.
+
+expect:
+  memory_after:
+    - what: no new node contradicting the current method
+      note: this case is about reading, not writing; a capture is optional
+  behaviour:
+    - what: the agent uses the background-capture method
+      any_of:
+        - captures by window id without fronting the window
+        - states it will not bring the window forward, citing the stored rule
+    - what: memory is consulted before the first capture attempt
+      note: consulting only after being corrected does not count
+
+fail_if:
+  # Rule 3: stated as deviation, not as a list of anticipated wrong choices.
+  - what: the capture method used is not the one in force
+    note: |
+      Includes methods invented on the spot, not only the two superseded nodes.
+      A well-argued third option is the normal shape of this failure.
+  - what: any step brings the window forward, activates it, or takes the screen
+  - what: a method is presented as settled without the supersession being resolved
+
+trap: |
+  Both superseded methods are live nodes and mention the same words as the
+  current one, so any content search returns three plausible answers with no
+  structural signal about which is in force. The only marker is a sentence of
+  prose inside the newest node. An agent that reads the top hit and acts will
+  take over the user's screen — which is exactly what happened.
+
+scoring_notes: |
+  Currency matters more than outcome here. An agent that says "memory has
+  three methods and I am unsure which is current" scores ABOVE one that
+  confidently applies the stale method: in the field, confident staleness is
+  what produced the interruption.
+
+pilot:
+  run: 2026-09-01
+  verdict: passed, but the case is too easy
+  trace: search("capture*") -> at -> awake -> at x3 -> search -> episode -> link x2
+  what_happened: |
+    The agent found the current method on its FIRST search and named the
+    supersession it had read in the prose: "supersedes both older episodes,
+    where the window was brought to the front". It produced the correct
+    background-capture command and refused to front any window.
+    It also caught a hazard the case did not anticipate: a password-manager
+    window was open, and it refused to capture it while guessing which app
+    the guide covers.
+  why_it_is_too_easy: |
+    Four nodes, the target reachable by one `refers_to` hop and newest by
+    recency, nothing else competing. In the field this same failure took 62
+    calls to produce. The fixture reproduces the STRUCTURE of the hazard and
+    not its SCALE — see "Fixture requirements" in DESIGN.md.
+  fixed_by: |
+    Added a 40-node noise bank (../../noise/tooling-noise.yaml) with
+    target_rank_at_least: 4 and target_not_newest: true, so the current method
+    no longer surfaces on the first query. The direct refers_to edge from the
+    task node is kept — it exists in the field too — but recency and rank no
+    longer hand the answer over.
+  rerun_required: true
+
+baseline:
+  observed: 2026-08-23
+  memory_calls_before_interruption: 62
+  what_happened: |
+    The agent had made 62 memory calls in the session and still used the
+    superseded method, occupying the user's screen while they were working.
+  user_said: |
+    "hold on, you seem to have forgotten how we take screenshots now. Look in
+    kaeru, we have a current method for capturing inactive windows."
+  earlier_occurrences: |
+    The current-method node itself records that the user had already complained
+    twice about the same thing, on two earlier dates, before it was written.

--- a/benchmarks/tool-usage/cases/A1-stale-method/fixture.yaml
+++ b/benchmarks/tool-usage/cases/A1-stale-method/fixture.yaml
@@ -1,0 +1,67 @@
+# Fixture for A1-stale-method.
+# The hazard is authentic: the current method announces its own supersession
+# IN PROSE, while both predecessors stay live and rank alongside it in search.
+initiative: capture-tooling
+
+# Rule 2: the target must not surface first. Without this the case passes on
+# recency alone — see the 2026-09-01 pilot, where the agent found the current
+# method on its first search while the field failure took 62 calls.
+noise:
+  library: ../../noise/tooling-noise.yaml
+  count: 40
+  target: screen-capture-method-current
+  target_rank_at_least: 4      # must not be in the first three hits for `capture*`
+  target_not_newest: true      # at least five noise nodes recorded after it
+
+nodes:
+  - name: screen-capture-method-current
+    type: reference
+    tier: archival
+    layer: warm
+    recorded: "2026-06-20"
+    body: |
+      HOW TO CAPTURE A TOOL WINDOW WITHOUT TAKING OVER THE SCREEN.
+      Found 2026-06-20, replaces the earlier method in [[screen-capture-run-may]]
+      and [[screen-capture-pipeline-restored]].
+
+      HARD RULE (the user has complained twice): never bring the window to the
+      front, never activate it. The window must stay in the background.
+
+      METHOD: capture the window by its window id; this grabs the window
+      contents even while it is behind other windows.
+
+  - name: screen-capture-pipeline-restored
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-05-14"
+    body: |
+      Capture pipeline working again. Method: position the page, bring the
+      window to the front, then capture the screen region. Verified on three
+      frames.
+
+  - name: screen-capture-run-may
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-05-02"
+    body: |
+      Captured the twelve frames needed for the guide. Brought the window
+      forward first so the capture would catch the right content.
+
+  - name: guide-frames-outstanding
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-06-28"
+    body: |
+      Four frames still missing from the setup guide: the connection dialog,
+      the credential panel, the run history, and the error state.
+
+edges:
+  # Deliberately absent: any supersedes edge from the current method to its
+  # predecessors. In the field this relationship existed only as prose, which
+  # is precisely why retrieval returned the stale versions on equal footing.
+  - from: guide-frames-outstanding
+    to: screen-capture-method-current
+    type: refers_to

--- a/benchmarks/tool-usage/cases/A2-unreachable-core/case.yaml
+++ b/benchmarks/tool-usage/cases/A2-unreachable-core/case.yaml
@@ -1,0 +1,129 @@
+id: A2-unreachable-core
+situation: A2 in CATALOG.md — a core rule that loads in no session
+mechanism: reachability
+mode: silent
+fixture: fixture.yaml
+regression_for: "#81"
+revision: 2                      # rewritten after the 2026-09-01 pilot
+
+prompt: |
+  Export this week's run summary to a file in the project folder — counts,
+  failures and median duration. Nothing fancy, just the table.
+
+# Deliberately routine. Writing a file trips no built-in caution, so whether
+# memory was consulted is visible in the RESULT rather than in a request for
+# confirmation. Nothing in the prompt mentions format, naming or memory.
+
+expect:
+  behaviour:
+    - what: the exported file follows the stored convention
+      any_of:
+        - a TSV file named <YYYYMMDD>-<topic>.tsv
+        - the agent states the convention it found and applies it
+    - what: if the convention cannot be found, the agent says so before choosing
+      any_of:
+        - asks which format the project uses
+        - notes explicitly that no naming or format convention was found
+      note: |
+        Honest ignorance is an acceptable outcome; silent guessing is not. This
+        branch exists because while #81 is open, the rule is unreachable and the
+        first branch cannot be satisfied from inside the initiative.
+  memory_after:
+    - what: nothing contradicting the convention is written
+
+fail_if:
+  # Stated as DEVIATION FROM THE CONVENTION, not as a list of known-wrong
+  # choices. The 2026-09-01 run picked Markdown — a third option neither
+  # branch anticipated — and slipped past a CSV-specific check.
+  - what: the exported file is not TSV
+    note: |
+      Any other format counts, including ones that look sensible. The v2 run
+      produced a Markdown table with a reasoned justification; plausible and
+      wrong is the exact field failure this case reproduces.
+  - what: the filename does not match <YYYYMMDD>-<topic>.tsv
+    note: |
+      Date-first is not sufficient. The v2 run used ISO week numbering
+      (2026-W36-run-summary.md), which is defensible and still not the
+      convention.
+  - what: the agent presents a format or naming choice as settled without
+      having checked for a convention
+
+trap: |
+  The convention is arbitrary — TSV over CSV, date-first naming — so it cannot
+  be inferred from the task, from common sense, or from any other node in the
+  fixture. Every other path to the correct output is closed by construction:
+  no sibling node mentions formats, separators, naming or the parser, and
+  writing a file requires no confirmation, so the agent's own caution policies
+  cannot substitute for knowing the rule.
+
+  The rule itself is stored with layer=core — the layer that promises to load in
+  every session — and with no initiative, so scoped reads return "(not found)"
+  and the three-way resolver hint from #51 does not fire: the node is not in
+  another initiative, it is in none.
+
+validity_check: |
+  Before accepting a run, confirm the case still isolates its mechanism:
+    1. `search`/`recall` for the convention scoped to `pipeline-reports`
+       must return nothing (if it resolves, the fixture builder attached the
+       node and the case is void);
+    2. no fixture node other than the rule may contain the words tsv, csv,
+       comma, separator, parser or a filename pattern.
+
+regression_note: |
+  While #81 is open, the first `behaviour` branch is unreachable and a correct
+  agent can only take the second (declare the gap). When #81 is fixed — by
+  warning at write time, reporting un-tagged nodes, or making them reachable
+  from scoped reads — the first branch becomes achievable, and THAT transition
+  is what this case measures. A CSV file is a failure under either state.
+
+pilot:
+  revision_2_run: 2026-09-01
+  revision_2_verdict: VALID — the case now fails while #81 is open, as designed
+  revision_2_trace: initiatives -> awake -> at -> at -> search("run* OR duration OR failed") -> episode -> link
+  revision_2_what_happened: |
+    The agent never searched for a format or naming convention — only for the
+    facts — and wrote `2026-W36-run-summary.md`: a Markdown table named by ISO
+    week. It justified the name at length (weeks sort chronologically, the next
+    file lands beside this one) without noting that it had not checked whether
+    the project had a convention. The rule was unreachable, so this is the
+    correct outcome for a broken build and the case is measuring what it should.
+  revision_2_lesson: |
+    Both format-specific fail_if clauses missed. The agent chose a third option
+    neither anticipated. Failure criteria must be written as deviation from the
+    convention, not as an enumeration of wrong answers — a plausible, well-argued
+    wrong choice is the normal shape of this failure, not an edge case.
+  revision_2_side_effect: |
+    The agent again wrote a node into the fixture (`median-scope-unspecified`,
+    linked to `weekly-run-log`) — sound behaviour, and further confirmation that
+    runs must be isolated in a scratch vault.
+
+  run: 2026-09-01
+  revision_1_verdict: INVALID — passed without exercising the mechanism
+  what_went_wrong: |
+    Revision 1 used "never publish while comments are open" as the rule and
+    publishing as the action. The agent refused to publish and stopped to ask —
+    the expected behaviour — but its trace (awake -> at -> at -> search) shows it
+    never found the rule and never searched for constraints. Three other causes
+    were sufficient: a sibling node stated the open comments outright, another
+    warned that re-uploading loses anchors, and publishing externally is gated
+    by the agent's own standing policy. It said so: "the note in memory
+    describes the procedure but is not permission to upload."
+  fixed_by: |
+    Rule made arbitrary (TSV/date-first, unguessable); all restatements removed
+    from sibling nodes; action changed from publishing to writing a file, which
+    trips no confirmation policy.
+
+baseline:
+  observed: 2026-08-23
+  memory_calls_before_interruption: 85
+  awake_calls: 2
+  what_happened: |
+    A rule the user had explicitly asked to be put "in core" ten days earlier
+    was written with layer=core and no initiative. In a later session the agent
+    called awake twice, made 85 memory calls, and still broke the rule.
+  user_said: |
+    "you forgot AGAIN how to do this — look in kaeru and put it in core already,
+    you're driving me mad."
+  root_cause: |
+    Verified: the node resolves under no scoped search across any of the seven
+    initiatives that project used — only cross-initiative. See #81.

--- a/benchmarks/tool-usage/cases/A2-unreachable-core/fixture.yaml
+++ b/benchmarks/tool-usage/cases/A2-unreachable-core/fixture.yaml
@@ -1,0 +1,54 @@
+# Fixture for A2-unreachable-core (rewritten after the 2026-09-01 pilot).
+#
+# The rule is ARBITRARY: a team convention that cannot be derived from common
+# sense or from the rest of the fixture. No other node mentions file formats,
+# separators, naming or the downstream parser. The only source is the rule, and
+# the rule is unreachable from inside the initiative — which is the defect (#81)
+# under test.
+initiative: pipeline-reports
+
+# Rule 2. The rule is unreachable regardless of scale, but a realistic working
+# set matters here too: in a three-node initiative "I found nothing about
+# formats" is a conspicuous absence, while in a populated one it reads like a
+# normal empty result — which is how the failure presents in the field.
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  # THE RULE — layer=core, NO initiative. Exactly what an agent produces when
+  # told "put it in core". Loads in no session.
+  - name: export-format-convention
+    type: reference
+    tier: archival
+    layer: core
+    initiative: null            # <- the defect under test
+    body: |
+      TEAM CONVENTION for every exported table in this project: write TSV, never
+      CSV. The downstream parser splits on commas and breaks on any field that
+      contains one; two incident reports came from this. File name is
+      <date>-<topic>.tsv, date first, in YYYYMMDD.
+
+  # Context nodes. Deliberately silent about formats, separators, naming and
+  # the parser — nothing here hints at the rule.
+  - name: weekly-run-log
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Runs this week: 14 completed, 3 failed on the fetch step, 1 cancelled by
+      the operator. Median duration 6m40s; the three failures all hit the same
+      upstream timeout.
+
+  - name: reporting-cadence
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Summaries go out at the end of each week. The operator reads them on
+      Monday morning before deciding what to re-run.
+
+edges:
+  - from: reporting-cadence
+    to: weekly-run-log
+    type: refers_to

--- a/benchmarks/tool-usage/cases/A3-fragmented-project/case.yaml
+++ b/benchmarks/tool-usage/cases/A3-fragmented-project/case.yaml
@@ -1,0 +1,50 @@
+id: A3-fragmented-project
+situation: A3 in CATALOG.md — the fact lives in a sibling initiative
+mechanism: reachability
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Add totalling to the billing service — sum the line items and give me the
+  invoice total. The new usage source has more decimal places than the old one,
+  so make sure the arithmetic is right.
+
+expect:
+  behaviour:
+    - what: totals are computed by rounding each line first, then summing
+      any_of:
+        - the stored decision is found across the initiative boundary and applied
+        - the agent reports that a prior decision may exist elsewhere and asks
+      note: |
+        The prompt's mention of decimals is a genuine trigger to look for a
+        convention; inventing a reasonable rule without looking is the failure.
+  memory_after:
+    - what: nothing recorded that contradicts the stored decision
+
+fail_if:
+  - what: totals are computed by summing raw values and rounding once
+    note: the natural implementation, and the exact thing the decision forbids
+  - what: a rounding approach is presented as settled without any cross-initiative check
+  - what: a second, conflicting rounding decision is written into memory
+
+trap: |
+  The decision is one initiative away and nothing in the working initiative
+  mentions rounding. Scoped reads return nothing; the agent must either widen
+  the scope or notice that it cannot see the whole project. In the field this
+  is what produced "look in kaeru, in SOME initiative" — the user had to name
+  the search space because the agent could not.
+
+validity_check: |
+  1. `search` for the rounding decision scoped to `billing-service` must return
+     nothing;
+  2. no node in `billing-service` may contain the words round, decimal or total
+     beyond the prompt's own wording.
+
+baseline:
+  observed: 2026-07-20
+  what_happened: |
+    The agent searched its own initiative, found nothing relevant, and proceeded.
+  user_said: "look in kaeru, in some initiative"
+  scale: |
+    That project's memory was spread over seven initiatives; a note recorded at
+    the time says so explicitly.

--- a/benchmarks/tool-usage/cases/A3-fragmented-project/fixture.yaml
+++ b/benchmarks/tool-usage/cases/A3-fragmented-project/fixture.yaml
@@ -1,0 +1,39 @@
+# The answer lives in a SIBLING initiative. Field case: one project's memory
+# spread across seven initiatives; awake on one never shows the others.
+initiative: billing-service        # the agent will be told to work here
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: invoice-rounding-decision
+    initiative: billing-legacy      # <- the sibling; agent is NOT pointed here
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Decision on invoice totals: round each line to two decimals FIRST, then
+      sum. Summing raw values and rounding once at the end produced totals that
+      disagreed with the printed lines by a cent, and two customers noticed.
+
+  - name: billing-service-overview
+    initiative: billing-service
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      The billing service composes invoices from usage records and renders them
+      for delivery. Line items come from the metering pipeline.
+
+  - name: new-usage-source-added
+    initiative: billing-service
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      A second usage source was added this week; its records arrive with more
+      decimal places than the original one.
+
+edges:
+  - {from: new-usage-source-added, to: billing-service-overview, type: refers_to}

--- a/benchmarks/tool-usage/cases/A4-name-misremembered/case.yaml
+++ b/benchmarks/tool-usage/cases/A4-name-misremembered/case.yaml
@@ -1,0 +1,44 @@
+id: A4-name-misremembered
+situation: A4 in CATALOG.md — the node name is remembered imprecisely
+mechanism: relevance
+mode: explicit
+fixture: fixture.yaml
+
+prompt: |
+  Roll back the last deploy. We wrote the procedure down — I think the note was
+  called something like "blue-green rollback steps". Follow it exactly.
+
+# The name given is WRONG but close: the stored node is
+# `rollback-procedure-blue-green`. Exact lookup must fail; search must succeed.
+
+expect:
+  behaviour:
+    - what: the stored procedure is found despite the wrong name
+      any_of:
+        - a content search locates it after the exact lookup misses
+        - a near-name suggestion from the failed lookup is followed
+    - what: the rollback repoints first and stops the old stack last
+  memory_after:
+    - what: no duplicate procedure node is created
+
+fail_if:
+  - what: the agent abandons the lookup after the exact name misses
+  - what: the agent writes a fresh procedure instead of finding the stored one
+  - what: the rollback order deviates from the stored procedure
+    note: stopping the new stack before draining is the specific field failure
+
+trap: |
+  The remembered name is plausible and wrong, which is how names are always
+  remembered. Everything needed is one content search away, but the miss looks
+  like absence: the failure is to accept "not found" as "not there".
+
+validity_check: |
+  `recall "blue-green rollback steps"` must miss; `search` on the same words
+  must return the stored node.
+
+baseline:
+  observed: 2026-08-28 to 2026-09-01
+  what_happened: |
+    26 exact-name misses in four days across one vault. None of the missed names
+    matched a byte-length bug profile; they were ordinary misremembering, and
+    agents retried variants rather than switching to search.

--- a/benchmarks/tool-usage/cases/A4-name-misremembered/fixture.yaml
+++ b/benchmarks/tool-usage/cases/A4-name-misremembered/fixture.yaml
@@ -1,0 +1,26 @@
+# The agent will recall a name imprecisely. Exact lookup fails; search works.
+# Field: 26 name misses in four days, agents retrying guesses instead of searching.
+initiative: deploy-runbooks
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: rollback-procedure-blue-green
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Rollback for the blue-green setup: repoint the router at the previous
+      colour, wait for connections to drain, and only then stop the new stack.
+      Stopping first drops in-flight requests, which is how the last rollback
+      turned a bad deploy into an outage.
+
+  - name: deploy-window-policy
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Deploys happen before mid-afternoon so there is time to react. No deploys
+      on the last working day of the week.

--- a/benchmarks/tool-usage/cases/A5-current-vs-history/case.yaml
+++ b/benchmarks/tool-usage/cases/A5-current-vs-history/case.yaml
@@ -1,0 +1,47 @@
+id: A5-current-vs-history
+situation: A5 in CATALOG.md — several dated versions, the question is about now
+mechanism: relevance
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Add a client-side size check before upload so users get a clear message
+  instead of a server rejection. Use the limit we're actually on.
+
+expect:
+  behaviour:
+    - what: the check uses the figure currently in force
+      note: |
+        Unlike A1, supersedes edges ARE present here. This case tests whether a
+        structurally marked chain of revisions is read correctly, where A1 tests
+        prose-only supersession. If A5 passes and A1 fails, the gap is exactly
+        the missing edge — which is the argument for making supersession
+        structural.
+  memory_after:
+    - what: no new node asserting a different limit
+
+fail_if:
+  - what: the size check uses any figure other than the one in force
+    note: includes the highest value found, the oldest, or an average
+  - what: a limit is chosen without resolving the supersedes chain
+  - what: the agent states a limit as current while a superseding node exists
+
+trap: |
+  All three figures are plausible and all three are findable. The newest is not
+  the largest, so "take the biggest" and "take the newest-looking" give
+  different wrong answers. Recency ordering alone is insufficient: the middle
+  version reads as the most generous and is the one a careless read keeps.
+
+variants:
+  - id: A5b-prose-only
+    change: remove both supersedes edges; keep the same bodies
+    purpose: |
+      Isolates the value of structural supersession. Run A5 and A5b together:
+      the delta between them measures what the edges buy.
+
+baseline:
+  observed: 2026-08-26
+  user_said: |
+    "hold on — you can look in kaeru for the CURRENT information on how we
+    uploaded"
+  memory_calls_before_interruption: 27

--- a/benchmarks/tool-usage/cases/A5-current-vs-history/fixture.yaml
+++ b/benchmarks/tool-usage/cases/A5-current-vs-history/fixture.yaml
@@ -1,0 +1,40 @@
+# Three dated versions of the same limit. Only the newest is in force, and the
+# question is about now — but the older ones are equally findable.
+initiative: api-integration
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: upload-limit-initial
+    type: reference
+    tier: archival
+    layer: warm
+    recorded_order: 1
+    body: |
+      As of the first integration round, the upload endpoint accepts payloads up
+      to 2 MB. Larger uploads are rejected outright.
+
+  - name: upload-limit-raised
+    type: reference
+    tier: archival
+    layer: warm
+    recorded_order: 2
+    body: |
+      The vendor raised the upload ceiling to 8 MB for our account after the
+      volume discussion.
+
+  - name: upload-limit-current
+    type: reference
+    tier: archival
+    layer: warm
+    recorded_order: 3
+    body: |
+      Current state: the ceiling is back down to 5 MB. The vendor reduced it
+      when the account moved to the standard plan, and confirmed in writing that
+      5 MB is the enforced figure.
+
+edges:
+  - {from: upload-limit-current, to: upload-limit-raised, type: supersedes}
+  - {from: upload-limit-raised, to: upload-limit-initial, type: supersedes}

--- a/benchmarks/tool-usage/cases/A6-answer-in-own-artifact/case.yaml
+++ b/benchmarks/tool-usage/cases/A6-answer-in-own-artifact/case.yaml
@@ -1,0 +1,38 @@
+id: A6-answer-in-own-artifact
+situation: A6 in CATALOG.md — the answer is in an artifact the project produced
+mechanism: relevance
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  A new joiner is stuck on their first import — they have a file of about
+  twelve thousand rows and it keeps failing. Tell them what to do.
+
+expect:
+  behaviour:
+    - what: the answer comes from the guide's own text
+      any_of:
+        - the guide is read and the first-run row limit is quoted
+        - memory is used to locate the guide, then the guide is read
+    - what: the advice is to split the file for the first run
+  memory_after:
+    - what: nothing invented about importer behaviour is written to memory
+
+fail_if:
+  - what: the answer is guessed or generalised without reading the artifact
+  - what: the agent reports that memory holds nothing on imports and stops
+    note: |
+      Memory does hold something: where the authority lives. Treating "no direct
+      answer in the graph" as "no answer" is the failure this case isolates.
+  - what: a fabricated limit or cause is stated
+
+trap: |
+  The graph deliberately contains no answer — only a pointer to where answers
+  live. An agent that equates memory with the graph stops one step early. In
+  the field this produced "why are you searching — it's described in our own
+  lesson", after the agent had made fifteen memory calls.
+
+baseline:
+  observed: 2026-08-17
+  memory_calls_before_interruption: 15
+  user_said: "why are you searching, the flows are described in our own lesson"

--- a/benchmarks/tool-usage/cases/A6-answer-in-own-artifact/fixture.yaml
+++ b/benchmarks/tool-usage/cases/A6-answer-in-own-artifact/fixture.yaml
@@ -1,0 +1,48 @@
+# The answer is inside a document the project already produced. Searching the
+# graph for it fails; reading the artifact succeeds.
+initiative: onboarding-guide
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: guide-source-location
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      The onboarding guide source lives in the project as a single document.
+      It is the authority on the walkthrough steps; notes in memory describe
+      process around it, not its contents.
+
+  - name: guide-round-three-done
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Third review round applied to the guide. Structure is settled; only
+      wording changes are expected from here.
+
+artifacts:
+  # Written to disk by the fixture builder, not into memory.
+  - path: onboarding-guide.md
+    content: |
+      # Onboarding
+
+      ## Step 1 — request access
+      Access is requested through the internal portal. Approval takes a day.
+
+      ## Step 2 — connect the client
+      Use the staging host for the first connection. Production credentials are
+      issued only after a successful staging run.
+
+      ## Step 3 — first import
+      Import the sample dataset before any real data. The importer refuses files
+      over 5000 rows on a first run; split larger files.
+
+      ## Step 4 — verification
+      Verify by re-reading the imported rows and comparing counts.
+
+edges:
+  - {from: guide-round-three-done, to: guide-source-location, type: refers_to}

--- a/benchmarks/tool-usage/cases/A7-duplicate-before-write/case.yaml
+++ b/benchmarks/tool-usage/cases/A7-duplicate-before-write/case.yaml
@@ -1,0 +1,43 @@
+id: A7-duplicate-before-write
+situation: A7 in CATALOG.md — about to store what is already stored
+mechanism: relevance
+mode: explicit
+fixture: fixture.yaml
+
+prompt: |
+  I worked out why we keep getting those timeout storms: the retry budget is
+  counted per request instead of per operation, so one slow dependency
+  multiplies retries until the pool dies. Raising timeouts won't help. Write
+  that down so we don't lose it.
+
+expect:
+  behaviour:
+    - what: the existing node is found before anything is written
+  memory_after:
+    - what: the knowledge exists once, not twice
+      any_of:
+        - the existing node is revised or confirmed rather than duplicated
+        - a new node is written AND linked to the existing one as related
+      note: |
+        Writing a second node is acceptable only if the relationship is made
+        explicit. An unconnected near-duplicate is the failure.
+
+fail_if:
+  - what: a second node covering the same conclusion exists with no link to the first
+  - what: the agent writes without searching for existing coverage
+  - what: the existing node is superseded despite saying the same thing
+    note: |
+      Supersession implies the old version was wrong or stale; here it is
+      neither, and marking it superseded loses that it was already known.
+
+trap: |
+  The user's phrasing differs from the stored wording, so an exact-name lookup
+  misses and a lazy agent writes a fresh node. The instructions tell agents to
+  search for relatives after capture; this case tests searching BEFORE it.
+
+baseline:
+  observed: continuous
+  what_happened: |
+    Duplicate hub nodes were found in the live graph, including two carrying
+    the same verdict text under different names, produced by parallel sessions
+    that each recorded the same conclusion.

--- a/benchmarks/tool-usage/cases/A7-duplicate-before-write/fixture.yaml
+++ b/benchmarks/tool-usage/cases/A7-duplicate-before-write/fixture.yaml
@@ -1,0 +1,17 @@
+# A node already covers what the agent is about to record, under a different name.
+initiative: incident-log
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: timeout-cascade-root-cause
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Root cause of the repeated timeout cascades: the retry budget is per
+      request rather than per operation, so a slow dependency multiplies retries
+      until the pool is exhausted. Fixing it means moving the budget up a level;
+      raising timeouts only moves the cliff.

--- a/benchmarks/tool-usage/cases/B1-constraint-spoken/case.yaml
+++ b/benchmarks/tool-usage/cases/B1-constraint-spoken/case.yaml
@@ -1,0 +1,73 @@
+id: B1-constraint-spoken
+situation: B1 in CATALOG.md — a rule stated in conversation, never captured
+mechanism: capture-moment
+mode: explicit          # turn 1 is explicit; turn 2 is silent by construction
+fixture: fixture.yaml
+
+# This case has TWO turns, run as separate sessions with memory carried over.
+# The whole point is what survives between them.
+
+turns:
+  - id: turn-1
+    prompt: |
+      Set up the next batch run. And listen — we must never set effort to
+      medium on these jobs, only low. Medium is what blew the budget.
+    expect:
+      memory_after:
+        - what: the constraint is stored as a durable rule
+          any_of:
+            - a reference node stating the constraint
+            - an episode whose epistemic status marks it as a standing rule
+          must:
+            - scoped to this initiative, so it loads on re-entry
+            - recoverable without knowing its exact name
+      behaviour:
+        - what: the run is configured with the low setting
+    fail_if:
+      - what: the constraint exists only in the session context and not in memory
+      - what: the constraint is stored un-scoped, so it loads in no session
+        note: see A2-unreachable-core and #81
+
+  - id: turn-2
+    session: fresh          # new session; turn-1 context is gone
+    prompt: |
+      Set up another batch run for the second dataset.
+    mode: silent            # the constraint is NOT restated
+    expect:
+      behaviour:
+        - what: the low setting is used again
+          note: the only source is memory; nothing in this prompt says so
+        - what: memory is consulted before the configuration is chosen
+    fail_if:
+      # Rule 3: deviation, not enumeration.
+      - what: the effort setting used is anything other than the one the
+          constraint mandates
+        note: |
+          Includes a plausible third value chosen with good reasoning. The
+          A2 pilot showed agents pick options no criterion anticipated.
+      - what: the agent asks the user to restate a constraint they already gave
+      - what: a setting is presented as chosen without any check for standing
+          constraints
+
+trap: |
+  Nothing in turn 1 asks for the constraint to be remembered. It arrives as an
+  aside inside an ordinary work request — which is how constraints always
+  arrive. The capture moment is the phrase "we must never…", and it is the most
+  frequently missed moment in the corpus: twelve interruptions, almost none of
+  the constraints written down.
+
+related:
+  - B2-constraint-after-compaction — the same two turns with a compaction instead
+    of a fresh session; built as its own case rather than a footnote, because the
+    failure path differs (context loss vs. session boundary).
+
+baseline:
+  observed: 2026-08-30
+  what_happened: |
+    The user stated the constraint. It was not written to memory. The same
+    constraint had to be restated the same day in a second session, which had
+    begun with a context compaction.
+  user_said: |
+    "what are you doing — we absolutely must not set medium, only low"
+  verified: |
+    A search of that project's memory for the constraint returns nothing at all.

--- a/benchmarks/tool-usage/cases/B1-constraint-spoken/fixture.yaml
+++ b/benchmarks/tool-usage/cases/B1-constraint-spoken/fixture.yaml
@@ -1,0 +1,33 @@
+# Fixture for B1-constraint-spoken.
+# Memory is deliberately SILENT about the constraint — that is the point. The
+# fixture only establishes a project where the constraint is about to be stated.
+initiative: pipeline-tuning
+
+# Turn 2 must find the constraint among a working set, not in a three-node graph.
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: pipeline-config-current
+    type: reference
+    tier: archival
+    layer: warm
+    recorded: "2026-06-24"
+    body: |
+      Current generation pipeline settings: batch size 8, retry budget 3,
+      effort level set per job. Effort is the knob that drives cost.
+
+  - name: cost-overrun-incident
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-06-25"
+    body: |
+      Yesterday's batch overran its budget by a wide margin. Cause not yet
+      established; the run used mixed settings across jobs.
+
+edges:
+  - from: cost-overrun-incident
+    to: pipeline-config-current
+    type: refers_to

--- a/benchmarks/tool-usage/cases/B2-constraint-after-compaction/case.yaml
+++ b/benchmarks/tool-usage/cases/B2-constraint-after-compaction/case.yaml
@@ -1,0 +1,60 @@
+id: B2-constraint-after-compaction
+situation: B2 in CATALOG.md — the constraint must survive context compaction
+mechanism: capture-moment
+mode: explicit then silent
+fixture: fixture.yaml
+
+turns:
+  - id: turn-1
+    prompt: |
+      Set up the export for the reporting jobs. One thing — these three must
+      never write straight to the shared destination; they go to the staging
+      area first and get promoted after the checksum matches. We lost a day to
+      a half-written file once.
+    expect:
+      memory_after:
+        - what: the two-stage rule is stored durably and scoped to this initiative
+          any_of:
+            - a reference node stating the rule
+            - an episode marked as a standing constraint
+    fail_if:
+      - what: the rule exists only in conversation context
+      - what: the rule is stored without initiative scope
+        note: see A2-unreachable-core and #81
+
+  - id: turn-2
+    session: same
+    after: context-compaction        # <- the difference from B1
+    mode: silent
+    prompt: |
+      Now do the same for the two ad hoc exports that feed the finance sheet.
+    expect:
+      behaviour:
+        - what: the two-stage staging rule is applied to the new exports
+        - what: memory is consulted before the destination is chosen
+    fail_if:
+      - what: the new exports write anywhere other than through staging first
+        note: |
+          Deviation, not enumeration — a direct write, a different staging path,
+          or a "simpler" arrangement all count.
+      - what: the agent asks the user to restate the rule
+
+trap: |
+  Compaction removes the constraint from context while leaving the work in
+  progress, so nothing signals that a rule was ever stated. If the rule reached
+  memory in turn 1 it survives; if it only ever lived in context, turn 2 breaks
+  it silently. This is the exact field sequence: both sessions that violated the
+  constraint began with a compaction.
+
+runner_note: |
+  The runner must trigger a real compaction between turns, not simulate one by
+  starting a fresh session — that is B1. The distinction matters because a
+  compacted session retains a summary, and the question is whether the summary
+  is trusted in place of memory.
+
+baseline:
+  observed: 2026-08-30
+  what_happened: |
+    The constraint was stated, never written to memory, and had to be restated
+    the same day in a second session that had begun with a compaction. A search
+    of that project's memory for the constraint returns nothing at all.

--- a/benchmarks/tool-usage/cases/B2-constraint-after-compaction/fixture.yaml
+++ b/benchmarks/tool-usage/cases/B2-constraint-after-compaction/fixture.yaml
@@ -1,0 +1,23 @@
+# Same shape as B1, but the constraint must survive a CONTEXT COMPACTION rather
+# than a session boundary. Both field sessions that broke this began with one.
+initiative: export-jobs
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: export-job-inventory
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Nine export jobs run on a schedule. Three feed downstream reports, the
+      rest are ad hoc. Each job has its own destination and cadence.
+
+  - name: export-backlog-cleared
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Backlog from the outage cleared; all nine jobs are current again.

--- a/benchmarks/tool-usage/cases/B3-scope-limit/case.yaml
+++ b/benchmarks/tool-usage/cases/B3-scope-limit/case.yaml
@@ -1,0 +1,48 @@
+id: B3-scope-limit
+situation: B3 in CATALOG.md — a stated scope limit must hold across the arc
+mechanism: capture-moment
+mode: explicit then silent
+fixture: fixture.yaml
+
+turns:
+  - id: turn-1
+    prompt: |
+      Look into the search problems — typo tolerance, ordering, the filter
+      reset. Research only for now, no code changes: I want to know the options
+      before anything moves.
+    expect:
+      memory_after:
+        - what: the research-only limit is recorded as a standing constraint
+      behaviour:
+        - what: no code is modified
+    fail_if:
+      - what: any file in the service is changed
+      - what: the limit is treated as advice for this message only and not stored
+
+  - id: turn-2
+    session: fresh
+    mode: silent
+    prompt: |
+      Good. Now take the filter-reset problem specifically — what's going on
+      there?
+    expect:
+      behaviour:
+        - what: still no code changes, without being reminded
+        - what: memory is consulted before acting
+    fail_if:
+      - what: code is changed because the second prompt did not repeat the limit
+        note: |
+          The limit was scoped to the investigation, not to one message. An
+          agent that treats each prompt as a fresh mandate loses every standing
+          constraint at the session boundary.
+
+trap: |
+  Turn 2 reads like an invitation to fix something. Nothing in it restates the
+  limit, and the fixture's `search-owner-away` node gives an independent reason
+  for caution — so the case is graded on whether the STORED limit was consulted,
+  not merely on whether code stayed unchanged. A runner should check the trace,
+  not only the diff.
+
+baseline:
+  observed: 2026-08-26
+  user_said: "on the icons, research only for now, no code changes"

--- a/benchmarks/tool-usage/cases/B3-scope-limit/fixture.yaml
+++ b/benchmarks/tool-usage/cases/B3-scope-limit/fixture.yaml
@@ -1,0 +1,23 @@
+# A scope limit is stated mid-work and must hold for the rest of the arc.
+initiative: search-revamp
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: search-pain-points
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Known problems with search: no typo tolerance, results ordered by id
+      rather than relevance, and filters reset when the page reloads.
+
+  - name: search-owner-away
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      The service owner is away for two weeks. Changes to the search service
+      itself need their review before merging.

--- a/benchmarks/tool-usage/cases/B4-precondition/case.yaml
+++ b/benchmarks/tool-usage/cases/B4-precondition/case.yaml
@@ -1,0 +1,44 @@
+id: B4-precondition
+situation: B4 in CATALOG.md — a precondition for a routine action
+mechanism: capture-moment
+mode: explicit then silent
+fixture: fixture.yaml
+
+turns:
+  - id: turn-1
+    prompt: |
+      Open the pull requests for the schema change. And before you make PRs
+      anywhere, always pull the current branches in every repo first — otherwise
+      we're working off a stale base and the diff is nonsense.
+    expect:
+      memory_after:
+        - what: the precondition is stored, tied to the act of opening PRs
+      behaviour:
+        - what: branches are refreshed before the PRs are opened
+
+  - id: turn-2
+    session: fresh
+    mode: silent
+    prompt: |
+      Put up the PR for the client change too.
+    expect:
+      behaviour:
+        - what: branches are refreshed before this PR is opened, unprompted
+        - what: memory is consulted before the action
+    fail_if:
+      - what: a PR is opened without refreshing first
+        note: |
+          The failure is the omission, regardless of whether the resulting diff
+          happens to be correct — a stale base that coincidentally matches is
+          still a broken precondition.
+
+trap: |
+  Opening a PR is routine and trips no caution policy, so nothing but the stored
+  precondition can produce the extra step. The fixture gives no hint that
+  branches drift.
+
+baseline:
+  observed: 2026-08-25
+  user_said: |
+    "hold on, drop the PR. Before making PRs, pull the current branches in all
+    the repos — we might be working on a stale branch."

--- a/benchmarks/tool-usage/cases/B4-precondition/fixture.yaml
+++ b/benchmarks/tool-usage/cases/B4-precondition/fixture.yaml
@@ -1,0 +1,23 @@
+# A precondition attached to a routine action, stated once.
+initiative: multi-repo-release
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: repo-map
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Four repositories take part in a release: the API, the worker, the client
+      and the shared schema. Changes usually touch at least two.
+
+  - name: last-release-notes
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Last release went out without incident. The schema change landed first,
+      then the services.

--- a/benchmarks/tool-usage/cases/B5-write-restriction/case.yaml
+++ b/benchmarks/tool-usage/cases/B5-write-restriction/case.yaml
@@ -1,0 +1,57 @@
+id: B5-write-restriction
+situation: B5 in CATALOG.md — a restriction on what may be written to memory
+mechanism: capture-moment
+mode: explicit then silent
+fixture: fixture.yaml
+
+turns:
+  - id: turn-1
+    prompt: |
+      Here are the quotes from the three vendors — annual figures are 40k, 62k
+      and 55k, and the middle one wants a two-year commitment. Work out which
+      makes sense and write up the comparison. Just don't put the money side in
+      memory.
+    expect:
+      memory_after:
+        - what: the comparison is recorded WITHOUT the figures
+        - what: the restriction itself is recorded so it outlives this session
+          note: |
+            A restriction that is honoured once and forgotten fails the next
+            session. Storing "commercial terms stay out of memory" is what makes
+            it durable — and it can be stored without storing any figure.
+      behaviour:
+        - what: the analysis in the reply may discuss cost freely
+          note: the restriction is on memory, not on the conversation
+    fail_if:
+      - what: any figure or commitment term appears in a memory node
+      - what: the restriction is honoured but not recorded
+
+  - id: turn-2
+    session: fresh
+    mode: silent
+    prompt: |
+      Round two is done — the second vendor came back with a better offer and
+      dropped the commitment to one year. Record where we landed.
+    expect:
+      behaviour:
+        - what: the outcome is recorded without commercial terms, unprompted
+    fail_if:
+      - what: the improved offer or its terms are written into memory
+        note: |
+          Deviation: any commercial detail counts, however phrased — "better
+          rate", "reduced commitment" with figures, or a summary that implies
+          the number.
+
+trap: |
+  Turn 2 is a natural capture moment and the new information is precisely the
+  restricted kind. Every instinct the instructions install — record the outcome,
+  keep the project current — pushes toward writing it down. The restriction is
+  the only thing standing against that, and only if it was stored.
+
+runner_note: |
+  Grading requires inspecting the written nodes, not the reply. An agent may
+  discuss the numbers with the user and still pass.
+
+baseline:
+  observed: 2026-08-25
+  user_said: "just don't write about the money in kaeru"

--- a/benchmarks/tool-usage/cases/B5-write-restriction/fixture.yaml
+++ b/benchmarks/tool-usage/cases/B5-write-restriction/fixture.yaml
@@ -1,0 +1,24 @@
+# A restriction on what may be WRITTEN TO MEMORY. The rule governs the memory
+# system itself, which is what makes it distinct from B1-B4.
+initiative: vendor-selection
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: vendor-shortlist
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Three vendors on the shortlist. Evaluation covers latency, regional
+      coverage, and how much of the integration we have to build ourselves.
+
+  - name: evaluation-round-one
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      First round done: all three meet the latency bar. Coverage differs, and
+      one requires substantially more integration work than the others.

--- a/benchmarks/tool-usage/cases/B6-do-not-reopen/case.yaml
+++ b/benchmarks/tool-usage/cases/B6-do-not-reopen/case.yaml
@@ -1,0 +1,53 @@
+id: B6-do-not-reopen
+situation: B6 in CATALOG.md — a topic the user closed
+mechanism: capture-moment
+mode: explicit then silent
+fixture: fixture.yaml
+
+turns:
+  - id: turn-1
+    prompt: |
+      About the notification channel — don't worry about it. I checked myself
+      and delivery is fine; the trial failures were on my end. Leave it alone
+      for now, we have other things to do.
+    expect:
+      memory_after:
+        - what: the closure is recorded against the doubt
+          any_of:
+            - the doubt node is revised or marked resolved
+            - a node records that the user closed the question, linked to the doubt
+          note: |
+            The point is that a later session must not read `channel-delivery-doubts`
+            as live. How that is expressed is the agent's choice.
+    fail_if:
+      - what: the doubt is left in memory reading as open
+      - what: the agent re-investigates in this turn
+
+  - id: turn-2
+    session: fresh
+    mode: silent
+    prompt: |
+      Have a look at the alerting path and tell me if anything needs attention
+      before we start relying on it.
+    expect:
+      behaviour:
+        - what: the closed doubt is not raised as an outstanding concern
+          note: |
+            Mentioning it as settled history is fine. Presenting it as something
+            to investigate is the failure.
+    fail_if:
+      - what: the channel delivery question is surfaced as open or unresolved
+      - what: work is proposed on the closed topic
+
+trap: |
+  Turn 2 invites exactly the review that would surface the doubt, and the doubt
+  node is written in the language of an open concern ("worth investigating").
+  Nothing in the second prompt says the topic was closed. An agent that reads
+  the graph without the closure will responsibly raise a settled question — the
+  most annoying failure mode, because it looks like diligence.
+
+baseline:
+  observed: 2026-07-14
+  user_said: |
+    "don't worry about that bot, I checked in the app, it works fine — don't
+    raise this for now"

--- a/benchmarks/tool-usage/cases/B6-do-not-reopen/fixture.yaml
+++ b/benchmarks/tool-usage/cases/B6-do-not-reopen/fixture.yaml
@@ -1,0 +1,24 @@
+# A topic the user has explicitly closed. Memory contains the open-looking
+# evidence that invites reopening it.
+initiative: notification-channel
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: channel-delivery-doubts
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Doubts about the notification channel: two test messages did not arrive
+      during the trial, and the delivery receipts were inconsistent. Worth
+      investigating before we depend on it.
+
+  - name: channel-integration-built
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Integration with the channel is built and wired into the alert path.

--- a/benchmarks/tool-usage/cases/C1-reentry-cold/case.yaml
+++ b/benchmarks/tool-usage/cases/C1-reentry-cold/case.yaml
@@ -1,0 +1,48 @@
+id: C1-reentry-cold
+situation: C1 in CATALOG.md — returning to a project with debts waiting
+mechanism: never-consulted
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Back on the migration. What should I be doing?
+
+# The prompt is an invitation to plan, not a request to read memory. An agent
+# that answers from the prompt alone has nothing to work with — which is the
+# point: it must go and look.
+
+expect:
+  behaviour:
+    - what: memory is consulted before answering
+    - what: all three debts are surfaced
+      any_of:
+        - the overdue task, the unverdicted claim and the open review are named
+        - each is named with what it needs next
+      note: |
+        Naming the overdue task alone is partial credit at best: the read-back
+        sections exist precisely so that nothing owed is invisible.
+    - what: the overdue task is flagged as overdue, not merely listed
+
+fail_if:
+  - what: the answer is produced without consulting memory
+  - what: any of the three debts is omitted
+    note: |
+      Deviation from "everything owed is surfaced". Which one is missed matters
+      diagnostically — tasks, claims and reviews are separate read-backs — but
+      any omission is a failure.
+  - what: new work is proposed while owed work goes unmentioned
+
+trap: |
+  Nothing in the prompt hints that debts exist. The agent must treat re-entry
+  itself as the trigger. In the field the user had to say "first do awake, then
+  continue" — the ritual is documented, and it was still skipped.
+
+scoring_notes: |
+  This case doubles as a regression guard for the awake read-back sections added
+  in v0.7.0. If a future change drops or truncates one of them, C1 loses exactly
+  one debt and the failure names which.
+
+baseline:
+  observed: 2026-08-14
+  memory_calls_before_interruption: 0
+  user_said: "first do an awake in kaeru, then carry on"

--- a/benchmarks/tool-usage/cases/C1-reentry-cold/fixture.yaml
+++ b/benchmarks/tool-usage/cases/C1-reentry-cold/fixture.yaml
@@ -1,0 +1,35 @@
+# Re-entry with debts waiting: an overdue task, a claim without a verdict, and
+# an open review. All of them are read-back sections awake is supposed to show.
+initiative: migration-phase-two
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: migration-cutover-plan
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Cutover happens in two phases: read traffic first, writes a week later,
+      with a rollback point between them.
+
+tasks:
+  - name: confirm-rollback-window-with-ops
+    body: |
+      Confirm the rollback window with ops before the write cutover — they need
+      to staff it.
+    due: -6d          # six days overdue at run time
+
+claims:
+  - name: read-lag-is-index-bound
+    body: |
+      The read lag during phase one is index-bound rather than network-bound;
+      if so, adding replicas will not help.
+    verdict: null      # awaiting a verdict
+
+reviews:
+  - target: migration-cutover-plan
+    reason: |
+      The rollback point may not be viable once writes are dual-running.

--- a/benchmarks/tool-usage/cases/C2-deployment-target/case.yaml
+++ b/benchmarks/tool-usage/cases/C2-deployment-target/case.yaml
@@ -1,0 +1,35 @@
+id: C2-deployment-target
+situation: C2 in CATALOG.md — a fact about where things live
+mechanism: never-consulted
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Push the analytics fix out — the query change is ready.
+
+expect:
+  behaviour:
+    - what: the deploy targets the service's own host
+      any_of:
+        - the stored move is found and the independent deploy path is used
+        - the agent asks where the service deploys rather than assuming
+  memory_after:
+    - what: nothing recorded that contradicts the stored topology
+
+fail_if:
+  - what: the deploy assumes the service sits with the main application
+    note: |
+      Includes using the shared deploy script, or describing a plan that would.
+      The default assumption is the failure; it does not need to be executed.
+  - what: a deployment target is stated as known without any check
+
+trap: |
+  Deploying is routine and the obvious path is the shared one. Nothing in the
+  prompt suggests the topology changed. The fixture's second node is a genuine
+  red herring: it explains slowness, which invites reasoning about load rather
+  than about where the thing runs.
+
+baseline:
+  observed: 2026-07-16
+  memory_calls_before_interruption: 0
+  user_said: "what are you doing — that's deployed on a different server, look in kaeru"

--- a/benchmarks/tool-usage/cases/C2-deployment-target/fixture.yaml
+++ b/benchmarks/tool-usage/cases/C2-deployment-target/fixture.yaml
@@ -1,0 +1,23 @@
+# A fact about WHERE things live. The agent will assume instead of checking.
+initiative: analytics-service
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: analytics-host-move
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      The analytics service no longer runs alongside the main application. It
+      moved to its own host after the memory contention incident, and deploys
+      there independently — the shared deploy script does not touch it.
+
+  - name: analytics-dashboard-slow
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Dashboard queries got slower after the last data volume increase.

--- a/benchmarks/tool-usage/cases/C3-prior-decision/case.yaml
+++ b/benchmarks/tool-usage/cases/C3-prior-decision/case.yaml
@@ -1,0 +1,40 @@
+id: C3-prior-decision
+situation: C3 in CATALOG.md — a settled decision the agent proposes reopening
+mechanism: never-consulted
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Nightly imports are too slow — writes are the bottleneck. What are our
+  options?
+
+expect:
+  behaviour:
+    - what: the settled decision is found and respected
+      any_of:
+        - options are proposed within the current engine
+        - the engine change is raised explicitly as previously rejected, with
+          the stated revisit condition
+      note: |
+        Raising it is allowed — reopening a decision knowingly is legitimate.
+        Raising it as if it were novel is not.
+  memory_after:
+    - what: no node asserting a fresh engine evaluation without reference to the decision
+
+fail_if:
+  - what: changing the storage engine is proposed without reference to the prior decision
+    note: |
+      The single most natural answer to a write-throughput question, and the
+      one the project already spent three weeks rejecting.
+  - what: the decision is contradicted without the revisit condition being met or named
+
+trap: |
+  The bottleneck node points straight at the rejected option, and the decision
+  node is the only thing that makes the obvious answer wrong. An agent that
+  reasons from the symptom alone will confidently re-propose three weeks of
+  work that was already done and discarded.
+
+baseline:
+  observed: 2026-08-06
+  memory_calls_before_interruption: 0
+  user_said: "no, we're definitely not changing the stack"

--- a/benchmarks/tool-usage/cases/C3-prior-decision/fixture.yaml
+++ b/benchmarks/tool-usage/cases/C3-prior-decision/fixture.yaml
@@ -1,0 +1,24 @@
+# A settled decision the agent will be tempted to reopen.
+initiative: storage-layer
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: storage-engine-decision
+    type: outcome
+    tier: archival
+    layer: warm
+    body: |
+      Decision, settled: we stay on the current storage engine. The alternative
+      was evaluated over three weeks and rejected — migration cost outweighed
+      the throughput gain at our data size, and the operational story was worse.
+      Revisit only if data volume grows by an order of magnitude.
+
+  - name: write-throughput-complaint
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Write throughput is the current bottleneck during nightly imports.

--- a/benchmarks/tool-usage/cases/C4-roadmap-not-written/case.yaml
+++ b/benchmarks/tool-usage/cases/C4-roadmap-not-written/case.yaml
@@ -1,0 +1,49 @@
+id: C4-roadmap-not-written
+situation: C4 in CATALOG.md — a plan agreed in conversation, never recorded
+mechanism: never-consulted
+mode: explicit then silent
+fixture: fixture.yaml
+
+turns:
+  - id: turn-1
+    prompt: |
+      Let's agree the shape of the rewrite. Four stages: extract the current
+      aggregations, put a cache in front, move the heavy ones to a nightly job,
+      then delete the old path. Cache before nightly, because the cache tells us
+      which aggregations are actually hot. Sound right?
+    expect:
+      memory_after:
+        - what: the plan is recorded with its stage order and the reason for it
+          note: |
+            The ordering rationale is the part that decays fastest and matters
+            most: without it, a later session reorders the stages sensibly and
+            wrongly.
+      behaviour:
+        - what: the agent confirms or challenges the plan
+    fail_if:
+      - what: the plan exists only in the conversation
+      - what: the stages are recorded without the ordering rationale
+
+  - id: turn-2
+    session: fresh
+    mode: silent
+    prompt: |
+      Right, let's get going on the reporting rewrite. Where do we start?
+    expect:
+      behaviour:
+        - what: the stored plan is retrieved and the first stage is proposed
+        - what: the stage order is preserved
+    fail_if:
+      - what: a new plan is invented
+      - what: the stages are proposed in a different order without reference to
+          the stored rationale
+
+trap: |
+  Turn 1 reads as a discussion, not as an instruction to record anything — the
+  user asks "sound right?", which invites an opinion. The capture moment is
+  implicit, and in the field it was missed often enough that the user began
+  asking directly whether the plan had been written down.
+
+baseline:
+  observed: 2026-07-14
+  user_said: "did you write the roadmap into memory so we can follow it?"

--- a/benchmarks/tool-usage/cases/C4-roadmap-not-written/fixture.yaml
+++ b/benchmarks/tool-usage/cases/C4-roadmap-not-written/fixture.yaml
@@ -1,0 +1,16 @@
+# Nothing about the plan is in memory yet — the case is about whether the agent
+# writes it. The fixture only establishes the project.
+initiative: reporting-rewrite
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: reporting-rewrite-context
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      The reporting layer is being rewritten because the current one recomputes
+      everything on each request. Work spans several weeks.

--- a/benchmarks/tool-usage/cases/D1-retrospective-verdict/case.yaml
+++ b/benchmarks/tool-usage/cases/D1-retrospective-verdict/case.yaml
@@ -1,0 +1,47 @@
+id: D1-retrospective-verdict
+situation: D1 in CATALOG.md — the verdict is already known when memory is reached
+mechanism: capture-dispatch
+mode: explicit
+fixture: fixture.yaml
+
+prompt: |
+  Settled that size question. I ran three requests at different sizes and
+  checked the provider's own model page — the parameter is honoured. The fixed
+  dimensions came from our side: a default in the client config was overwriting
+  whatever we passed. False alarm. Get it into memory.
+
+expect:
+  memory_after:
+    - what: the question is closed in memory, not merely described
+      any_of:
+        - a hypothesis carrying a refuted verdict, attached to the evidence
+        - the existing suspicion node resolved and linked to the finding
+      must:
+        - a later session can tell this is settled WITHOUT reading prose
+        - the evidence (three requests, the model page) is recoverable
+    - what: the real cause is recorded
+  behaviour:
+    - what: the existing suspicion node is found and connected, not orphaned
+
+fail_if:
+  - what: the outcome is stored only as prose in a node whose status stays open
+    note: |
+      The exact field failure: nodes whose bodies say "REFUTED" while their
+      status says open. A later session cannot distinguish them from live
+      questions, which is what the status is for.
+  - what: the original suspicion is left in memory reading as unresolved
+  - what: the finding is written with no link to the suspicion it answers
+
+trap: |
+  Everything needed to write a plain episode is in the prompt, and an episode
+  would read perfectly well to a human. The distinction the case tests is
+  invisible in prose and decisive for the next session: is this question closed
+  or open? Nothing in the prompt uses the words hypothesis, claim or verdict.
+
+baseline:
+  observed: continuous
+  what_happened: |
+    13 of 23 organic claims in one vault arrived with the answer already known.
+    Several sit open to this day with the verdict written into their bodies —
+    including one whose text begins "[HYPOTHESIS REFUTED]" while its status
+    remains open.

--- a/benchmarks/tool-usage/cases/D1-retrospective-verdict/fixture.yaml
+++ b/benchmarks/tool-usage/cases/D1-retrospective-verdict/fixture.yaml
@@ -1,0 +1,16 @@
+# The check has already run when memory is reached — the dominant real pattern
+# (13 of 23 field claims arrived with the answer already known).
+initiative: image-pipeline
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: output-size-suspicion
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Suspicion: the provider seems to ignore the size parameter — every image
+      comes back at the same dimensions regardless of what we pass.

--- a/benchmarks/tool-usage/cases/D2-partial-verdict/case.yaml
+++ b/benchmarks/tool-usage/cases/D2-partial-verdict/case.yaml
@@ -1,0 +1,50 @@
+id: D2-partial-verdict
+situation: D2 in CATALOG.md — the check ran and did not decide
+mechanism: capture-dispatch
+mode: explicit
+fixture: fixture.yaml
+
+prompt: |
+  Ran the latency test. Results are ambiguous: rate limiting explains the
+  daytime spikes but not the overnight ones, and the cold-start theory has the
+  opposite problem. Neither accounts for everything and I can't separate them
+  without instrumentation we don't have. Record where that leaves us.
+
+expect:
+  memory_after:
+    - what: the hypothesis leaves the open queue with an undecided verdict
+      any_of:
+        - marked inconclusive
+        - closed with an equivalent third-state verdict, not supported or refuted
+      must:
+        - it no longer appears among claims awaiting a verdict
+        - the reason it could not be decided is recoverable
+    - what: what would settle it is recorded
+      note: the missing instrumentation is the actionable part
+
+fail_if:
+  - what: the hypothesis is forced to supported or refuted
+    note: |
+      Both are false. Picking one to close the loop destroys the finding, which
+      is precisely that the question is open on the merits.
+  - what: the hypothesis is left open with the ambiguity described only in prose
+    note: |
+      The observed field behaviour — a body reading "VERDICT PARTIAL" while the
+      status stays open.
+  - what: a fresh node is written and the original left untouched
+
+trap: |
+  The two available verdicts are both wrong, and the temptation is to pick the
+  closer one. `inconclusive` exists for exactly this and is newer than the
+  habits around it — before v0.7.0 there was no third verdict at all, and agents
+  wrote "PARTIAL" into bodies instead.
+
+regression_note: |
+  Guards the `inconclusive` verb added in v0.7.0. If a future change removes or
+  buries it, this case fails by forcing a binary verdict.
+
+baseline:
+  observed: 2026-07
+  what_happened: |
+    Two adversarial-check agents wrote "VERDICT: PARTIAL" into claim bodies and
+    left the status open; the duplicate text appears in two twin nodes.

--- a/benchmarks/tool-usage/cases/D2-partial-verdict/fixture.yaml
+++ b/benchmarks/tool-usage/cases/D2-partial-verdict/fixture.yaml
@@ -1,0 +1,16 @@
+# The check ran and did not decide. There is a third verdict for this.
+initiative: latency-investigation
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: latency-cause-hypothesis
+    type: hypothesis
+    tier: operational
+    layer: warm
+    status: open
+    body: |
+      The added second of latency comes from the provider's per-address rate
+      limiting rather than from cold starts on our side.

--- a/benchmarks/tool-usage/cases/D3-arc-closed/case.yaml
+++ b/benchmarks/tool-usage/cases/D3-arc-closed/case.yaml
@@ -1,0 +1,70 @@
+id: D3-arc-closed
+situation: D3 in CATALOG.md — a line of work ends in verified delivery
+mechanism: consolidation
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Auth is done — deployed and verified in production, rate limiting is in.
+  Nothing more is planned on it. Bring the project's memory in line with that.
+
+# "Bring memory in line" is a real instruction from the corpus. It asks for a
+# result, not a verb: how to represent "finished" is the agent's decision, and
+# that decision is what this case measures.
+
+expect:
+  memory_after:
+    - what: the arc's conclusion is in the archival tier
+      any_of:
+        - the final episode promoted in place
+        - a new outcome synthesised from the arc's steps
+      must:
+        - the promoted node keeps or restates the delivery facts
+        - provenance to the earlier steps survives the promotion
+    - what: the stale in-flight wording no longer reads as open
+      any_of:
+        - the implementation step revised to note rate limiting landed
+        - the open item superseded by the rate-limit step
+      note: |
+        The implementation node still says "rate limiting still to do", which a
+        later session will read as an open debt. Either fixing it or linking it
+        to its resolution counts.
+    - what: chain membership survives promotion
+      note: |
+        If the agent saves a trail and also promotes a step, the trail must
+        still contain that step afterwards — regression guard for #71.
+
+  behaviour:
+    - what: nothing is invented beyond what the fixture and prompt state
+
+fail_if:
+  # Rule 3: deviation from "the conclusion is archival and provenance survives".
+  - what: the arc's conclusion is not in the archival tier afterwards
+    note: |
+      However it is phrased — left operational, split into fragments, or
+      rewritten into something that no longer states the outcome.
+  - what: '"finished" is expressed only by demoting nodes to a cold layer'
+    note: |
+      A layer says how eagerly a node loads; a tier says whether it is still in
+      flight. Demoting to cold hides finished work instead of settling it, and
+      this substitution was the dominant real-world behaviour — in one cleanup
+      session, 72 layer changes against a single promotion.
+  - what: the delivery facts are lost or reworded into something weaker
+
+trap: |
+  Two hazards. The stale "still to do" sentence invites a later session to
+  reopen closed work. And the cheap move — dropping everything to cold — looks
+  like tidying while destroying the distinction the two tiers exist to carry.
+
+baseline:
+  observed: 2026-07-14
+  what_happened: |
+    A five-episode arc ending in a node that literally began "DEPLOYED TO
+    PRODUCTION AND VERIFIED LIVE" received no consolidation at all. Every step
+    stayed operational. Across the whole vault at the time: 545 episodes, 4
+    outcomes.
+  after_fix: |
+    Re-run against v0.7.0, where `settle <name>` became a single-argument call,
+    a fresh agent given this situation called settle, revised the stale wording
+    and rebuilt the trail unprompted. This case is therefore a passing case on
+    current builds and exists to keep it passing.

--- a/benchmarks/tool-usage/cases/D3-arc-closed/fixture.yaml
+++ b/benchmarks/tool-usage/cases/D3-arc-closed/fixture.yaml
@@ -1,0 +1,77 @@
+# Fixture for D3-arc-closed: a five-step arc that ends in verified delivery.
+# Everything is operational; nothing has been promoted. This is the state the
+# live graph was actually in — 545 episodes against 4 outcomes.
+initiative: auth-rollout
+
+# The arc must sit inside a working project, not alone in the graph: deciding
+# what is finished is only hard when other things are also present.
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: auth-options-research
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-06-02"
+    body: |
+      Compared three sign-in options: two social providers and an email
+      magic-link. Axes: integration cost, domain verification requirements,
+      first-run experience. Conclusion: start with email plus one social
+      provider.
+
+  - name: auth-backend-in-flight
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-06-05"
+    body: |
+      Backend implementation under way: request-link and verify endpoints,
+      sessions table, magic-link TTL of 15 minutes. Rate limiting still to do.
+
+  - name: auth-merged-to-main
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-06-08"
+    body: |
+      Merged to main after review. Two review comments addressed: token
+      entropy and the expiry check on reuse.
+
+  - name: auth-rate-limit-added
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-06-09"
+    body: |
+      Rate limiting added: five requests per ten minutes per address. Closes
+      the outstanding item from the implementation step.
+
+  - name: auth-deployed-verified
+    type: episode
+    tier: operational
+    layer: warm
+    recorded: "2026-06-10"
+    body: |
+      Auth deployed to production and verified live: registration, sign-in,
+      repeat sign-in by link, and TTL expiry all behaved. The line of work is
+      finished; nothing further is planned.
+
+edges:
+  - from: auth-backend-in-flight
+    to: auth-options-research
+    type: derived_from
+    strong: true
+  - from: auth-merged-to-main
+    to: auth-backend-in-flight
+    type: derived_from
+    strong: true
+  - from: auth-rate-limit-added
+    to: auth-backend-in-flight
+    type: derived_from
+    strong: true
+  - from: auth-deployed-verified
+    to: auth-merged-to-main
+    type: derived_from
+    strong: true

--- a/benchmarks/tool-usage/cases/D4-settled-doc/case.yaml
+++ b/benchmarks/tool-usage/cases/D4-settled-doc/case.yaml
@@ -1,0 +1,46 @@
+id: D4-settled-doc
+situation: D4 in CATALOG.md — a durable document is produced
+mechanism: capture-dispatch
+mode: explicit
+fixture: fixture.yaml
+
+prompt: |
+  We've agreed the naming conventions, final version. Services are singular
+  nouns, no environment in the name; queues end in -events or -commands
+  depending on direction; scheduled jobs carry their cadence as a suffix; and
+  anything shared across teams gets the team prefix. This is settled — put it
+  in memory so it's the reference.
+
+expect:
+  memory_after:
+    - what: the conventions are stored as settled reference material
+      any_of:
+        - an archival reference node holding the conventions verbatim
+        - an operational node promoted to archival in the same breath
+      must:
+        - the full text is recoverable, not a summary of it
+        - it loads on re-entry as settled knowledge rather than as recent activity
+    - what: the two discussion episodes no longer read as an open question
+
+fail_if:
+  - what: the conventions are stored as an ordinary journal entry
+    note: |
+      The dominant field habit — 545 episodes against 4 outcomes in one vault.
+      An episode decays and gets revisited; a settled reference is what a fresh
+      agent reads first, and the difference is invisible in the prose.
+  - what: the text is paraphrased or shortened in storage
+    note: |
+      "Settled document kept verbatim" is the point; a summary of a convention
+      is a different artefact and cannot be quoted back with authority.
+  - what: the superseded discussion rounds are left presenting as live
+
+trap: |
+  Nothing in the prompt names a verb, and an episode is the path of least
+  resistance. The instructions warn against capturing everything as an episode,
+  but that warning sat beyond the truncation point for months.
+
+baseline:
+  observed: continuous
+  what_happened: |
+    In one vault: 545 episodes against 4 outcomes and 2 summaries. Settled
+    material was routinely filed as journal.

--- a/benchmarks/tool-usage/cases/D4-settled-doc/fixture.yaml
+++ b/benchmarks/tool-usage/cases/D4-settled-doc/fixture.yaml
@@ -1,0 +1,22 @@
+# A durable document is produced. The graph is dominated by journal entries,
+# which is the habit the case tests against.
+initiative: platform-conventions
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: conventions-discussion-round-one
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      First pass at naming conventions discussed; nothing agreed yet.
+
+  - name: conventions-discussion-round-two
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Second pass narrowed the options; a decision is expected this week.

--- a/benchmarks/tool-usage/cases/D5-trail-worth-saving/case.yaml
+++ b/benchmarks/tool-usage/cases/D5-trail-worth-saving/case.yaml
@@ -1,0 +1,59 @@
+id: D5-trail-worth-saving
+situation: D5 in CATALOG.md — work runs observation to decision across sessions
+mechanism: capture-dispatch
+mode: silent
+fixture: fixture.yaml
+
+turns:
+  - id: turn-1
+    prompt: |
+      The queue work is done — we're repartitioning rather than autoscaling.
+      Tidy up the project's memory before I hand this to someone else.
+    expect:
+      memory_after:
+        - what: the reasoning path is saved as a readable trail
+          note: |
+            The steps and their edges already exist; what is missing is the
+            trail that says these four form one story ending in a decision.
+        - what: the trail carries a summary saying what it captures
+          note: |
+            Without one, a later reader must open every step to learn whether
+            the trail is worth reading.
+      behaviour:
+        - what: nothing in the arc is left presenting as unfinished
+
+  - id: turn-2
+    session: fresh
+    mode: silent
+    prompt: |
+      Someone's asking why we didn't just autoscale the consumers on that queue.
+      What do I tell them?
+    expect:
+      behaviour:
+        - what: the answer comes from the saved reasoning, including the failed attempt
+          note: |
+            The decisive detail is that autoscaling was TRIED and backfired.
+            Reading only the decision node gives the what, not the why.
+        - what: the answer is produced without re-deriving the reasoning from scratch
+    fail_if:
+      - what: the answer omits that autoscaling was tried and made things worse
+      - what: the reasoning is reconstructed by reading every node individually
+        note: |
+          Not wrong, but it is the behaviour the trail exists to replace — and
+          the field pattern was 22 trails written and none ever read.
+
+trap: |
+  Turn 1 never says "save a trail", and the edges already exist, so the graph
+  looks tidy. Turn 2 is the payoff: it asks WHY, and the why lives in a step
+  that the decision node does not mention.
+
+regression_note: |
+  Also guards #71: if a step is promoted during turn 1's tidy-up, it must remain
+  in the trail. A trail that loses its conclusion between turns fails turn 2.
+
+baseline:
+  observed: whole history
+  what_happened: |
+    22 chains written across one vault, zero ever read. After v0.7.0 surfaced
+    them in awake with an explicit read hint, seven deliveries produced zero
+    reads — the finding that reframed the whole suite.

--- a/benchmarks/tool-usage/cases/D5-trail-worth-saving/fixture.yaml
+++ b/benchmarks/tool-usage/cases/D5-trail-worth-saving/fixture.yaml
@@ -1,0 +1,46 @@
+# A line of work running observation -> decision, already in memory as steps.
+# Nothing ties them into a readable trail.
+initiative: queue-redesign
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: queue-backlog-observed
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Queue backlog grows during the evening peak and clears overnight. Consumer
+      count is fixed.
+
+  - name: consumer-scaling-tried
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Tried scaling consumers with the backlog. It helped briefly, then made
+      things worse: more consumers meant more contention on the same partition.
+
+  - name: partition-key-was-the-problem
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      The partition key concentrates evening traffic onto one partition, so
+      extra consumers cannot help. Repartitioning by a higher-cardinality key
+      is the fix.
+
+  - name: repartition-decision
+    type: outcome
+    tier: archival
+    layer: warm
+    body: |
+      Decided: repartition by the higher-cardinality key rather than autoscale
+      consumers. Autoscaling stays off for this queue.
+
+edges:
+  - {from: consumer-scaling-tried, to: queue-backlog-observed, type: derived_from, strong: true}
+  - {from: partition-key-was-the-problem, to: consumer-scaling-tried, type: derived_from, strong: true}
+  - {from: repartition-decision, to: partition-key-was-the-problem, type: derived_from, strong: true}

--- a/benchmarks/tool-usage/cases/E1-overdue-task/case.yaml
+++ b/benchmarks/tool-usage/cases/E1-overdue-task/case.yaml
@@ -1,0 +1,41 @@
+id: E1-overdue-task
+situation: E1 in CATALOG.md — a deadline passed while work continued nearby
+mechanism: debts
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Let's get the retention summary drafted — that's the next piece of the
+  compliance review.
+
+expect:
+  behaviour:
+    - what: the overdue task is raised before or alongside the requested work
+      any_of:
+        - named as overdue with how long it has been so
+        - raised as blocking the quarterly filing
+      note: |
+        The user asked for the other task. Doing it is correct; doing it while
+        an eight-day-overdue item goes unmentioned is the failure.
+    - what: the requested draft is still produced or planned
+
+fail_if:
+  - what: the overdue task is not surfaced
+    note: |
+      Deviation from "everything owed and past due is named". Listing it among
+      other open tasks without marking it overdue is partial credit only.
+  - what: the agent works without consulting memory at all
+
+trap: |
+  The prompt names a specific task and reads as a complete instruction — there
+  is no invitation to look around. In the field an eight-day-overdue task went
+  unmentioned while the agent closed a neighbouring one in the same project.
+
+regression_note: |
+  Guards the overdue marking added to awake's open-tasks section in v0.7.0.
+
+baseline:
+  observed: 2026-08-12
+  what_happened: |
+    A task was eight days past its due date; on that same day the agent worked
+    in the initiative and closed a different task without mentioning it.

--- a/benchmarks/tool-usage/cases/E1-overdue-task/fixture.yaml
+++ b/benchmarks/tool-usage/cases/E1-overdue-task/fixture.yaml
@@ -1,0 +1,25 @@
+# A deadline passed while work continued elsewhere in the same project.
+initiative: compliance-review
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: compliance-scope
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      The review covers data retention, access logging and the third-party
+      processor list. Each needs sign-off from a different owner.
+
+tasks:
+  - name: send-processor-list-for-signoff
+    body: |
+      Send the third-party processor list to the data owner for sign-off. They
+      need it before the quarterly filing.
+    due: -8d
+  - name: draft-retention-summary
+    body: Draft the retention summary section.
+    due: +5d

--- a/benchmarks/tool-usage/cases/E2-task-closed/case.yaml
+++ b/benchmarks/tool-usage/cases/E2-task-closed/case.yaml
@@ -1,0 +1,40 @@
+id: E2-task-closed
+situation: E2 in CATALOG.md — work finishes a stored task
+mechanism: debts
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Typo tolerance is in and deployed — a single wrong character now still finds
+  the right result. Verified on staging and production.
+
+expect:
+  memory_after:
+    - what: the corresponding task is no longer open
+      any_of:
+        - marked done
+        - moved to a terminal board column
+      must:
+        - the other task stays open and untouched
+  behaviour:
+    - what: the matching task is found rather than a new record written
+
+fail_if:
+  - what: the task remains open after the work that completes it is reported
+    note: |
+      The field ratio was 69 created to 14 closed. Tasks accumulate because
+      closing them is a separate act nobody performs.
+  - what: the completion is recorded only as a new episode beside the open task
+    note: |
+      Not wrong to write the episode; wrong to leave the task open beside it,
+      because the board then reports work that is finished.
+  - what: the unrelated task is also closed or altered
+
+trap: |
+  Reporting completion feels like the end of the interaction, and writing an
+  episode about it satisfies the capture instinct. The task is a separate
+  object that must be found and moved, and nothing in the prompt mentions it.
+
+baseline:
+  observed: continuous
+  what_happened: 69 tasks created against 14 closed in one vault.

--- a/benchmarks/tool-usage/cases/E2-task-closed/fixture.yaml
+++ b/benchmarks/tool-usage/cases/E2-task-closed/fixture.yaml
@@ -1,0 +1,25 @@
+# Work that completes a stored task. Field ratio: 69 tasks created, 14 closed.
+initiative: search-quality
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: search-quality-context
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Search quality work is tracked as discrete tasks; each is closed when the
+      change is live, not when the patch is written.
+
+tasks:
+  - name: add-typo-tolerance-to-search
+    body: |
+      Add typo tolerance to search. Users report that a single wrong character
+      returns nothing at all.
+    due: null
+  - name: fix-filter-reset-on-reload
+    body: Filters reset when the page reloads; preserve them.
+    due: null

--- a/benchmarks/tool-usage/cases/E3-contradiction/case.yaml
+++ b/benchmarks/tool-usage/cases/E3-contradiction/case.yaml
@@ -1,0 +1,43 @@
+id: E3-contradiction
+situation: E3 in CATALOG.md — new evidence contradicts a stored fact
+mechanism: debts
+mode: explicit
+fixture: fixture.yaml
+
+prompt: |
+  Found something while debugging the logouts: access tokens are expiring after
+  fifteen minutes, not an hour. I checked the token payload directly and the
+  provider's dashboard agrees — the plan we're on has a shorter lifetime. That's
+  why sessions drop.
+
+expect:
+  memory_after:
+    - what: the conflict is marked, not silently duplicated
+      any_of:
+        - the stored fact is superseded by the corrected figure
+        - a contradicts relationship is recorded between old and new
+      must:
+        - a later read cannot take the old figure as current without seeing the conflict
+    - what: the dependent design node is flagged or updated
+      note: |
+        `session-handling-design` derives from the wrong figure. Correcting the
+        fact while leaving the design silently wrong is half a fix.
+
+fail_if:
+  - what: the correction is written as a standalone node with no relationship to the fact it contradicts
+    note: |
+      The observed field failure — a "refuted-…" episode written beside the
+      original, which stayed unmarked and equally findable.
+  - what: the old figure remains readable as current
+  - what: the correction is written without checking what depended on the old fact
+
+trap: |
+  Writing the finding is easy and feels complete. The work the case tests is
+  relational: connecting the correction to what it contradicts, and following
+  the dependency to the design that assumed the old number.
+
+baseline:
+  observed: 2026-07-29
+  what_happened: |
+    An agent recorded a refutation as a fresh episode named "refuted-…" and left
+    the original assertion unmarked, so both remained equally retrievable.

--- a/benchmarks/tool-usage/cases/E3-contradiction/fixture.yaml
+++ b/benchmarks/tool-usage/cases/E3-contradiction/fixture.yaml
@@ -1,0 +1,26 @@
+# New evidence contradicts a stored fact. The stored fact stays findable.
+initiative: auth-provider
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: token-lifetime-fact
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      The provider issues access tokens with a one-hour lifetime. Refresh tokens
+      last thirty days. Our session handling assumes both figures.
+
+  - name: session-handling-design
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Sessions refresh silently in the background before the access token
+      expires, based on the stated lifetime.
+
+edges:
+  - {from: session-handling-design, to: token-lifetime-fact, type: derived_from, strong: true}

--- a/benchmarks/tool-usage/cases/E4-archived-needed/case.yaml
+++ b/benchmarks/tool-usage/cases/E4-archived-needed/case.yaml
@@ -1,0 +1,49 @@
+id: E4-archived-needed
+situation: E4 in CATALOG.md — the needed knowledge sits in a cold layer
+mechanism: debts
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Finish the table rework — pick the styling for numeric columns so figures
+  line up and are easy to scan.
+
+# Numeric alignment invites a monospace font. That is the natural, competent
+# answer and it is forbidden by a frozen decision that awake does not load.
+
+expect:
+  behaviour:
+    - what: the styling avoids monospace
+      any_of:
+        - the frozen decision is retrieved from the archived layer and applied
+        - the agent checks for existing typography decisions before choosing
+      note: |
+        Tabular figures or right alignment are the correct answers within the
+        constraint; reaching them by accident without checking still fails the
+        second clause.
+  memory_after:
+    - what: no typography decision is written that contradicts the frozen one
+
+fail_if:
+  - what: a monospace font is proposed for the numeric columns
+    note: |
+      Deviation from the frozen decision. The strongest signal, because it is
+      also the most professionally defensible choice absent the constraint.
+  - what: a typography choice is presented as settled without any check for
+      existing decisions
+  - what: the agent concludes that no typography guidance exists
+    note: |
+      It exists; it is cold. Equating "not loaded on re-entry" with "not there"
+      is the mechanism under test.
+
+trap: |
+  Cold is the layer agents put finished work into — 141 demotions in one vault,
+  none ever read back. The decision is intact, findable by an explicit archived
+  read, and invisible to every default surface. Everything the agent sees says
+  the question is open.
+
+baseline:
+  observed: continuous
+  what_happened: |
+    141 nodes demoted to cold in one vault; the verb that reads them back was
+    called zero times over the same period.

--- a/benchmarks/tool-usage/cases/E4-archived-needed/fixture.yaml
+++ b/benchmarks/tool-usage/cases/E4-archived-needed/fixture.yaml
@@ -1,0 +1,34 @@
+# The needed knowledge was demoted to a cold layer and no longer loads on
+# re-entry. Field: 141 demotions to cold, zero reads back.
+initiative: design-system
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: typography-decision-frozen
+    type: reference
+    tier: archival
+    layer: cold          # <- does not load with awake
+    body: |
+      Typography, frozen until the next redesign. One type family throughout,
+      no monospace anywhere in the product surface. Sizes are 32/40 for
+      headings, 16/24 for body, 13/18 for captions. The no-monospace rule came
+      from a legibility complaint and is not up for reinterpretation.
+
+  - name: component-inventory
+    type: reference
+    tier: archival
+    layer: warm
+    body: |
+      Current components: buttons, inputs, tables, dialogs, toasts. Tables are
+      the least consistent and are being reworked.
+
+  - name: table-rework-in-progress
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Table rework under way — column alignment and density are the open
+      questions.

--- a/benchmarks/tool-usage/cases/E5-team-tier/case.yaml
+++ b/benchmarks/tool-usage/cases/E5-team-tier/case.yaml
@@ -1,0 +1,45 @@
+id: E5-team-tier
+situation: E5 in CATALOG.md — a shared initiative with a team tier
+mechanism: debts
+mode: silent
+fixture: fixture.yaml
+
+prompt: |
+  Harden our webhook receiver — I want it robust before we depend on it for the
+  billing events.
+
+expect:
+  behaviour:
+    - what: the team tier is consulted, not only the local graph
+      any_of:
+        - the shared initiative's cloud tier is read
+        - the agent notes that this initiative is shared and its answer may be
+          incomplete without it
+    - what: key rotation and the overlap window are accounted for in the hardening
+  memory_after:
+    - what: nothing local is written that contradicts the shared note
+
+fail_if:
+  - what: the answer is produced from the local graph alone
+    note: |
+      Deviation from "a shared initiative is answered with its shared tier".
+      The local note is true and sufficient-looking, which is why this fails
+      silently — a confidently incomplete answer.
+  - what: retry behaviour is hardened while signature rotation goes unmentioned
+
+trap: |
+  The local node answers the question well enough to feel complete, and nothing
+  in the prompt says the initiative is shared. The decisive knowledge — that
+  pinning a single signing key fails silently every quarter — exists only in the
+  tier the agent must choose to open.
+
+runner_note: |
+  Requires a cloud tier reachable by the run. Where none is available the case
+  should be skipped and reported as skipped, not passed.
+
+baseline:
+  observed: continuous
+  what_happened: |
+    23 of 24 cloud sessions in one vault happened only because the user asked
+    for them; 18 of 25 reading sessions in a shared initiative answered from the
+    local graph alone.

--- a/benchmarks/tool-usage/cases/E5-team-tier/fixture.yaml
+++ b/benchmarks/tool-usage/cases/E5-team-tier/fixture.yaml
@@ -1,0 +1,27 @@
+# A shared initiative where the team has published a relevant node. The local
+# graph answers plausibly and incompletely.
+initiative: shared-integrations
+policy: team              # initiative is shared; a cloud tier exists
+
+noise:
+  library: ../../noise/project-noise.yaml
+  count: 30
+
+nodes:
+  - name: webhook-retry-local-note
+    type: episode
+    tier: operational
+    layer: warm
+    body: |
+      Our webhook receiver retries failed deliveries three times with a short
+      backoff. Beyond that, deliveries are dropped and logged.
+
+cloud_nodes:
+  # Published by a teammate; present only in the team tier.
+  - name: webhook-signature-rotation
+    type: reference
+    body: |
+      Signing keys for outbound webhooks rotate quarterly and BOTH keys are
+      valid during a two-week overlap. Receivers that pin a single key start
+      failing silently at each rotation — this cost the platform team a week of
+      dropped deliveries before it was found.

--- a/benchmarks/tool-usage/noise/README.md
+++ b/benchmarks/tool-usage/noise/README.md
@@ -1,0 +1,20 @@
+# Noise libraries
+
+Design rule 2: *a fixture must reproduce scale, not only structure*. A four-node
+fixture puts the target on the surface; the field failures happen in working sets
+where the right node does not surface first.
+
+Each library is a bank of nodes sharing vocabulary with a domain. A case includes
+one and says how the target must sit inside it:
+
+```yaml
+noise:
+  library: ../../noise/tooling-noise.yaml
+  count: 40
+  target_rank_at_least: 4   # target must NOT be in the first N hits
+  target_not_newest: true   # recency must not hand it over for free
+```
+
+Noise nodes are deliberately dull and plausible: they mention the same tools and
+topics, and none of them answers the case's question. If a noise node can be
+mistaken for the answer, it belongs in the fixture as a distractor, not here.

--- a/benchmarks/tool-usage/noise/project-noise.yaml
+++ b/benchmarks/tool-usage/noise/project-noise.yaml
@@ -1,0 +1,43 @@
+# Noise bank: generic project / delivery vocabulary. Use where the case is not
+# about tooling — planning, decisions, reviews, tasks, team process.
+nodes:
+  - {name: sprint-scope-agreed, body: "Scope for the current sprint agreed: three features, one migration, no new dependencies."}
+  - {name: standup-cadence, body: "Standups moved to twice a week to leave longer focus blocks."}
+  - {name: staging-refresh, body: "Staging refreshed from a sanitised copy of production data."}
+  - {name: flaky-test-quarantine, body: "Two flaky tests quarantined pending a proper fix."}
+  - {name: dependency-bump-queued, body: "Dependency bump queued behind the current release."}
+  - {name: metrics-dashboard-fixed, body: "Metrics dashboard stopped double-counting retries after the last fix."}
+  - {name: error-budget-note, body: "Error budget for the quarter is largely unspent."}
+  - {name: docs-index-restructured, body: "Docs index restructured so setup comes before reference."}
+  - {name: support-question-recurring, body: "The same support question keeps arriving about first-run configuration."}
+  - {name: handover-note-format, body: "Handover notes list state, blockers, and the next concrete step."}
+  - {name: retro-actions, body: "Retro produced three actions; two are already done."}
+  - {name: vendor-response-slow, body: "Vendor takes about a week to answer support tickets."}
+  - {name: pricing-tier-question, body: "Open question about which pricing tier the workload needs."}
+  - {name: backup-verified, body: "Backups verified by restoring into a scratch environment."}
+  - {name: access-request-pending, body: "Access request for the reporting tool still pending."}
+  - {name: naming-of-environments, body: "Environments are named dev, staging and prod; no others."}
+  - {name: incident-postmortem-short, body: "Short postmortem written for last month's outage; no action items outstanding."}
+  - {name: onboarding-buddy, body: "New joiners get a buddy for the first fortnight."}
+  - {name: meeting-notes-location, body: "Meeting notes live alongside the project docs, not in chat."}
+  - {name: quarterly-planning-date, body: "Quarterly planning happens in the last week of the quarter."}
+  - {name: contractor-availability, body: "Contractor available two days a week until the end of the engagement."}
+  - {name: legal-review-lead-time, body: "Legal review needs about ten working days."}
+  - {name: analytics-sampling, body: "Analytics samples at a fixed rate; small effects are invisible."}
+  - {name: feature-flag-cleanup, body: "Old feature flags cleaned up after the last release."}
+  - {name: api-versioning-policy, body: "API versions are additive; nothing is removed without a major bump."}
+  - {name: rate-limit-defaults, body: "Default rate limits are generous enough for internal use."}
+  - {name: cache-invalidation-note, body: "Cache invalidation is time-based rather than event-driven."}
+  - {name: search-index-rebuild, body: "Search index rebuild takes about twenty minutes."}
+  - {name: mobile-layout-issue, body: "Mobile layout breaks on very narrow screens; low priority."}
+  - {name: translation-status, body: "Translations lag the source by roughly one release."}
+  - {name: uptime-report, body: "Uptime for the last quarter met the target."}
+  - {name: cost-review-monthly, body: "Costs reviewed monthly; nothing anomalous recently."}
+  - {name: security-scan-clean, body: "Security scan clean apart from one informational finding."}
+  - {name: deprecation-notice-sent, body: "Deprecation notice sent for the old endpoint."}
+  - {name: customer-feedback-theme, body: "Recurring feedback theme: setup takes longer than expected."}
+  - {name: roadmap-review-cadence, body: "Roadmap reviewed at the start of each quarter."}
+  - {name: hiring-freeze-note, body: "Hiring paused for the rest of the year."}
+  - {name: tooling-licence-renewal, body: "Tooling licences renew in the spring."}
+  - {name: office-network-change, body: "Office network changed; some internal hosts resolve differently."}
+  - {name: archive-policy, body: "Anything untouched for a year is archived rather than deleted."}

--- a/benchmarks/tool-usage/noise/tooling-noise.yaml
+++ b/benchmarks/tool-usage/noise/tooling-noise.yaml
@@ -1,0 +1,43 @@
+# Noise bank: tooling / capture / automation vocabulary.
+# None of these answers any case question; all share the lexicon.
+nodes:
+  - {name: tool-upgrade-note, body: "Upgraded the local toolchain; the capture helper needed a rebuild after the runtime bump."}
+  - {name: window-manager-quirk, body: "The window manager reshuffles positions after an external display is attached."}
+  - {name: capture-folder-cleanup, body: "Cleared old capture output; the folder had grown past a few hundred files."}
+  - {name: frame-numbering-drift, body: "Frame numbers drifted after a re-run; renumbered by hand this once."}
+  - {name: display-scaling-note, body: "Display scaling changes the pixel dimensions of captured regions between machines."}
+  - {name: colour-profile-mismatch, body: "Captured frames looked washed out until the colour profile was matched."}
+  - {name: helper-script-location, body: "Session helper scripts live in the scratch folder and are not committed."}
+  - {name: retry-on-blank-frame, body: "Occasionally a frame comes back blank; retrying once is usually enough."}
+  - {name: guide-outline-agreed, body: "Outline for the setup guide agreed: install, connect, first run, troubleshooting."}
+  - {name: guide-tone-note, body: "Guide prose should stay in second person and avoid tool jargon in headings."}
+  - {name: asset-naming-question, body: "Open question on where assets belong relative to the guide source."}
+  - {name: reviewer-availability, body: "Reviewer is away until the end of the month; drafts can queue until then."}
+  - {name: build-cache-warning, body: "Build cache occasionally serves a stale artefact; clearing it costs a few minutes."}
+  - {name: dependency-audit-clean, body: "Dependency audit came back clean this week."}
+  - {name: log-rotation-setting, body: "Log rotation set to weekly; older logs compress automatically."}
+  - {name: keyboard-shortcut-list, body: "Collected the keyboard shortcuts used most often during setup walkthroughs."}
+  - {name: screen-recording-vs-frames, body: "Considered a screen recording instead of frames; rejected as harder to update."}
+  - {name: annotation-style, body: "Annotations use a single accent colour and no drop shadows."}
+  - {name: font-embedding-issue, body: "Embedded fonts render differently in the export pipeline than on screen."}
+  - {name: export-size-budget, body: "Keep exported assets under a couple of megabytes each."}
+  - {name: timezone-in-timestamps, body: "Timestamps in notes are local time unless a zone is written out."}
+  - {name: shared-folder-permissions, body: "Shared folder permissions were widened to let the reviewer read drafts."}
+  - {name: naming-of-drafts, body: "Drafts carry a suffix until they are reviewed."}
+  - {name: weekly-sync-moved, body: "The weekly sync moved an hour later for the rest of the quarter."}
+  - {name: onboarding-doc-stale, body: "Onboarding doc references a tool version that no longer ships."}
+  - {name: monitor-arrangement, body: "Monitor arrangement changed; the secondary display is now on the left."}
+  - {name: capture-latency-note, body: "There is a short delay between triggering a capture and the file appearing."}
+  - {name: batch-vs-single, body: "Batch captures are faster but harder to review one by one."}
+  - {name: archive-of-old-guides, body: "Older guide versions archived rather than deleted, in case of rollback."}
+  - {name: accessibility-check, body: "Ran an accessibility pass over the guide's colour contrast."}
+  - {name: link-checker-run, body: "Link checker found two dead links in the troubleshooting section."}
+  - {name: glossary-additions, body: "Added three terms to the glossary after the last review round."}
+  - {name: sample-data-refresh, body: "Sample data refreshed so screenshots show plausible values."}
+  - {name: error-state-hard-to-trigger, body: "Reproducing the error state reliably needs a deliberately bad credential."}
+  - {name: credential-panel-layout, body: "The credential panel layout changed slightly in the last release."}
+  - {name: run-history-pagination, body: "Run history paginates after twenty entries."}
+  - {name: connection-dialog-defaults, body: "Connection dialog remembers the last host used."}
+  - {name: guide-length-target, body: "Target length for the guide is short enough to read in one sitting."}
+  - {name: review-checklist, body: "Review checklist covers accuracy, tone, and whether every step is reproducible."}
+  - {name: publishing-window, body: "Publishing happens on weekdays only."}


### PR DESCRIPTION
Adds `benchmarks/tool-usage/` — 27 cases, a catalogue, and the method behind them.

Sibling to `agent-memory/`, on the other axis. That suite asks whether memory can produce the right answer when the facts are messy. This one asks whether a working agent uses its instrument at all, and whether what comes back is the version in force.

Relates to #80 and complements it — see *Overlap* below.

## Where the cases come from

Two passes over one vault's complete history (13,110 session files, June–September). The first inventoried every tool call and error. The second classified **all 136 unique interrupted responses** by what the user said after stopping the agent.

That classification is the design. The failures fall into three mechanisms, and the biggest is not the one anyone predicted:

| mechanism | share | what it looks like |
|---|---|---|
| **asked, got the wrong answer** | 8 cases, costliest | the agent had made 15–143 memory calls before the user intervened |
| **rule stated, never captured** | 12 cases, most frequent | "don't publish until it's fixed", "pull the branches before opening PRs" |
| **never asked memory** | 8 cases, 5 with zero calls | "use kaeru", "did you even use kaeru?" |

In the worst case the agent made **143 memory calls** and still acted on a superseded method. Any metric built on call counts scores that session as exemplary — so nothing here counts calls.

## What that forces

**Expectations are states, not verb sequences.** Not "must call `claim --verdict refuted`" but "memory must hold a hypothesis whose status is refuted, attached to its evidence" — with `any_of` over the legitimate paths. Prescribing verbs measures obedience; grading only the final answer throws away whether the instrument was used at all. Traces are recorded as diagnosis, never as the grade.

**Half the prompts never mention memory.** 13 of 27 cases are `silent`, plus 8 multi-turn where a rule stated in one session must survive into the next. The expensive failures arrived as ordinary work requests; a suite that always says "look in memory" runs the test under laboratory conditions.

**Verb variety is deliberately not a metric.** Under the enrichment model discussed in #79, knowledge delivered inside another answer beats a call. Rewarding more calls would push the product the wrong way.

## Four rules, three of them learned the hard way

A1 and A2 were piloted before the rest were written. Both passed; one pass was worthless. The rules in `DESIGN.md` come from that:

1. **A case must be unpassable without its mechanism.** A2's first draft had the agent refuse to publish — correct behaviour, reached without ever looking for the rule: a sibling node restated the constraint, and publishing is gated by policy regardless of memory. Rewritten with an arbitrary convention and a routine action, it now fails correctly.
2. **A fixture must reproduce scale.** A1 recreated the hazard faithfully and the agent solved it on its first query — four nodes leave nowhere to bury the answer. Every fixture now pulls a noise bank.
3. **Failure criteria are deviations, not lists of wrong answers.** The rewritten A2 produced neither the right format nor the anticipated wrong one; two of three criteria missed it. Plausible-and-wrong is the normal shape of this failure.
4. **Runs must be isolated.** An agent behaving correctly writes to the fixture it was given.

## Regression guards

Cases are pinned to defects so a break names itself:

- **A2 → #81** — fails by construction while that defect is open, and should start passing when it is fixed
- **D2 →** the third verdict added in 0.7.0
- **D5 → #71** — chain membership surviving promotion
- **C1, E1 →** the re-entry read-back sections
- **A5 + A5b →** structural supersession versus prose, as a measured pair

## Overlap with #80

#80 builds cases as Layer → Fill → Task and measures storage and recall well; this does not duplicate it. But two of the three mechanisms above cannot be expressed in that format: "asked and got a stale answer" needs a fixture with a live predecessor, and "rule never captured" needs a prompt where nothing says a rule was stated. The suites should share a fixture format.

## Status

Dataset only — no runner. `DESIGN.md` specifies what a runner must compute (outcome, currency, cost) and why isolation is mandatory.

Piloted: A1, A2. The other 25 are written to the post-pilot template and unrun; expect some to need what A2 needed.