### PR TITLE
feat(mcp): a stdio relay, and the bundle that ships it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,9 @@ config = "0.14"
 # not available: it tied each session to its own subprocess and made
 # multi-session use impossible (RocksDB is single-writer).
 rmcp = { version = "1.6", features = ["server", "transport-streamable-http-server", "macros"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "net", "time"] }
+# `io-std` and `process` are the stdio bridge: it reads stdin/stdout and, when
+# no daemon answers, starts one.
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "net", "time", "io-std", "io-util", "process"] }
 tokio-util = "0.7"
 tokio-stream = "0.1"
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json", "query"] }

--- a/contrib/install/package-release.sh
+++ b/contrib/install/package-release.sh
@@ -60,6 +60,16 @@ fi
 # of chasing the wrong cause.
 export CARGO_PROFILE_RELEASE_LTO=false
 
+# MCPB names platforms the way node does; rust names them by triple.
+mcpb_platform() {
+    case "$1" in
+        *-apple-darwin)  echo darwin ;;
+        *-linux-*)       echo linux  ;;
+        *-windows-*)     echo win32  ;;
+        *) echo "unknown MCPB platform for target $1" >&2; exit 1 ;;
+    esac
+}
+
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$ROOT"
 
@@ -94,14 +104,58 @@ for target in "${TARGETS[@]}"; do
 
     archive="kaeru-${TAG}-${target}.tar.gz"
     tar -C "$stage" -czf "$DIST/$archive" kaeru-mcp
+
+    # …and the same binary as an MCP Bundle. A .mcpb is a zip carrying the
+    # server plus a manifest, which is what lets a client install kaeru with
+    # nothing to download and nothing to build.
+    #
+    # The manifest runs the binary with `--stdio`, never bare. Bare would start
+    # a second daemon over whichever one already owns the vault, and the
+    # substrate is single-writer — the loser fails on the RocksDB lock. With
+    # `--stdio` each client gets a relay of its own and the daemon stays one.
+    bundle="kaeru-mcp-${TAG}-${target}.mcpb"
+    mkdir -p "$stage/server"
+    mv "$stage/kaeru-mcp" "$stage/server/kaeru-mcp"
+    sed -e "s/__VERSION__/${TAG#v}/" -e "s/__PLATFORM__/$(mcpb_platform "$target")/" \
+        "$ROOT/contrib/mcpb/manifest.json" > "$stage/manifest.json"
+    ( cd "$stage" && zip -qr "$DIST/$bundle" manifest.json server )
     rm -rf "$stage"
 
     echo "    -> dist/$archive"
+    echo "    -> dist/$bundle"
 done
 
 echo "==> SHA256SUMS"
-( cd "$DIST" && sha256sum kaeru-*.tar.gz | tee SHA256SUMS )
+# Bundles are summed alongside the tarballs: server.json carries a
+# `fileSha256` for the .mcpb, and MCP clients verify it before installing.
+( cd "$DIST" && sha256sum kaeru-*.tar.gz kaeru-*.mcpb | tee SHA256SUMS )
 
+# The registry entry, generated rather than kept by hand: it carries a
+# download URL and a SHA-256 per bundle, and both change every release. A
+# hand-edited server.json is a server.json that publishes last release's hash.
+echo "==> server.json"
+REL="https://github.com/LamantinAI/kaeru/releases/download/$TAG"
+packages=""
+for target in "${TARGETS[@]}"; do
+    bundle="kaeru-mcp-${TAG}-${target}.mcpb"
+    sum=$(cd "$DIST" && sha256sum "$bundle" | cut -d' ' -f1)
+    [[ -n "$packages" ]] && packages="$packages,"
+    packages="$packages
+    {
+      \"registryType\": \"mcpb\",
+      \"identifier\": \"$REL/$bundle\",
+      \"fileSha256\": \"$sum\",
+      \"transport\": { \"type\": \"streamable-http\", \"url\": \"http://127.0.0.1:9876/mcp\" }
+    }"
+done
+sed -e "s/__VERSION__/${TAG#v}/" "$ROOT/contrib/mcpb/server.json.template" \
+    | python3 -c "import sys; sys.stdout.write(sys.stdin.read().replace('__PACKAGES__', '''$packages'''))" \
+    > "$DIST/server.json"
+echo "    -> dist/server.json"
+
+echo
+echo "Publish to the MCP registry (maintainer, once per release):"
+echo "    mcp-publisher login github && mcp-publisher publish dist/server.json"
 echo
 echo "Done. Upload contents of dist/ to the GitHub release for $TAG:"
 ls -lh "$DIST"

--- a/contrib/mcpb/manifest.json
+++ b/contrib/mcpb/manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifest_version": "0.3",
+  "name": "kaeru",
+  "display_name": "kaeru",
+  "version": "__VERSION__",
+  "description": "Cognitive memory for LLM agents: a typed, bi-temporal graph the agent queries as tools, so work survives between sessions.",
+  "long_description": "kaeru gives an agent somewhere to keep what it learns. Episodes and claims while the work is live, settled outcomes and references once it is not, with the reasoning trail between them saved and re-readable.\n\nOne daemon per machine owns the vault; this bundle installs a relay that forwards your client's session to it and starts it if it is not already running. That way several clients — Claude Desktop, Claude Code, Cursor — share one memory instead of racing for it.",
+  "author": {
+    "name": "LamantinAI",
+    "url": "https://lamantin-ai.com"
+  },
+  "homepage": "https://lamantin-ai.com/products/kaeru/",
+  "documentation": "https://github.com/LamantinAI/kaeru#readme",
+  "support": "https://github.com/LamantinAI/kaeru/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LamantinAI/kaeru.git"
+  },
+  "license": "LicenseRef-BSL-1.1",
+  "keywords": ["mcp", "memory", "agent-memory", "knowledge-graph", "bitemporal", "rust"],
+  "server": {
+    "type": "binary",
+    "entry_point": "server/kaeru-mcp",
+    "mcp_config": {
+      "command": "${__dirname}/server/kaeru-mcp",
+      "args": ["--stdio"]
+    }
+  },
+  "compatibility": {
+    "platforms": ["__PLATFORM__"]
+  }
+}

--- a/contrib/mcpb/server.json.template
+++ b/contrib/mcpb/server.json.template
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.LamantinAI/kaeru",
+  "title": "kaeru",
+  "description": "Cognitive memory for LLM agents: a typed, bi-temporal graph the agent queries as tools, so work survives between sessions. Local-first, with an optional shared tier for a team.",
+  "version": "__VERSION__",
+  "repository": {
+    "url": "https://github.com/LamantinAI/kaeru",
+    "source": "github"
+  },
+  "websiteUrl": "https://lamantin-ai.com/products/kaeru/",
+  "packages": [__PACKAGES__
+  ]
+}

--- a/kaeru-mcp/README.md
+++ b/kaeru-mcp/README.md
@@ -10,6 +10,43 @@ would race for the lock — the second one to start fails. Service-mode
 solves that by putting one writer in front of the vault and letting
 many readers/writers connect over HTTP.
 
+## Clients that only speak stdio
+
+The daemon is the point: one process owns the vault, and every session
+connects to it. But most MCP clients only know how to spawn a server and talk
+to it over stdio, which left them unable to reach kaeru at all.
+
+`kaeru-mcp --stdio` is a relay for exactly that. It forwards a client's session
+to the daemon — starting the daemon first if nothing is answering — so the
+client gets the stdio server it expects and the vault still has one writer.
+
+```bash
+claude mcp add kaeru -- kaeru-mcp --stdio
+```
+
+It relays frames rather than interpreting them, so a method added upstream
+passes through without the relay needing to learn it. Logs go to stderr,
+because stdout carries the protocol.
+
+### As a bundle
+
+`contrib/install/package-release.sh` also builds a `.mcpb` per platform — an
+MCP Bundle, which is a zip carrying the binary and a manifest. A client that
+installs one needs no Rust toolchain and no separate download; the manifest
+runs the binary with `--stdio`, never bare.
+
+Bare would start a second daemon over whichever one already owns the vault,
+and the loser fails on the RocksDB lock. That is why the bundle exists as a
+packaging of the relay rather than of the server.
+
+The same script writes `dist/server.json` for the
+[MCP Registry](https://registry.modelcontextprotocol.io), with a download URL
+and SHA-256 per bundle:
+
+```bash
+mcp-publisher login github && mcp-publisher publish dist/server.json
+```
+
 ## Build & install
 
 ```bash

--- a/kaeru-mcp/src/main.rs
+++ b/kaeru-mcp/src/main.rs
@@ -24,6 +24,7 @@ mod params;
 mod server;
 mod settings;
 mod sse;
+mod stdio_bridge;
 mod tools;
 mod utils;
 
@@ -56,6 +57,27 @@ use crate::settings::KaeruMcpConfig;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let mcp_config = KaeruMcpConfig::new()?;
+
+    // `--stdio` is the bridge, not a second server: it forwards to the daemon
+    // that owns the vault rather than opening the vault itself. The flag is
+    // read straight off argv because the daemon has no other arguments, and a
+    // parser for exactly one of them would be furniture.
+    if std::env::args().any(|a| a == "--stdio") {
+        let url = format!(
+            "http://{}:{}{}",
+            mcp_config.listen_address, mcp_config.listen_port, mcp_config.mount_path
+        );
+        // stdout carries the protocol, so every log line has to go to stderr —
+        // one stray byte on stdout and the client sees a malformed frame.
+        tracing_subscriber::registry()
+            .with(EnvFilter::from(mcp_config.log_level.as_str()))
+            .with(fmt::layer().with_writer(std::io::stderr))
+            .init();
+        let bridge = stdio_bridge::Bridge::new(url, Some(mcp_config.auth_token.clone()));
+        bridge.ensure_daemon().await?;
+        bridge.run().await?;
+        return Ok(());
+    }
 
     let level = Level::from_str(&mcp_config.log_level)?;
     tracing_subscriber::registry()

--- a/kaeru-mcp/src/stdio_bridge.rs
+++ b/kaeru-mcp/src/stdio_bridge.rs
@@ -1,0 +1,208 @@
+//! `kaeru-mcp --stdio` — a relay from a client that speaks stdio to the daemon
+//! that owns the vault.
+//!
+//! kaeru is deliberately not a stdio server: the substrate is a single-writer
+//! RocksDB, so a subprocess per agent session would race for the LOCK and the
+//! second one would lose. That decision is right and this module does not
+//! revisit it — but it left every stdio-only MCP client unable to reach kaeru
+//! at all, which is most of them.
+//!
+//! So: the client spawns *this*, and this forwards to the one daemon. Each
+//! session gets a process of its own, as stdio clients expect, and the vault
+//! still has exactly one writer.
+//!
+//! **It relays frames rather than modelling them.** A proxy built out of an
+//! MCP client and server would have to understand every method to pass it on,
+//! and would silently drop whatever it had not been taught — a new method, a
+//! notification, a capability added upstream. This forwards the JSON-RPC that
+//! arrives and returns what comes back, so it stays correct as the protocol
+//! grows.
+
+use std::io;
+use std::process::Stdio;
+use std::time::Duration;
+
+use reqwest::Client;
+use reqwest::header::{ACCEPT, CONTENT_TYPE, HeaderValue};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::time::sleep;
+
+/// Header the streamable-HTTP transport uses to bind a client to its session.
+const SESSION_HEADER: &str = "mcp-session-id";
+
+/// How long to wait for a daemon we just started to begin answering.
+const START_TIMEOUT: Duration = Duration::from_secs(20);
+
+pub struct Bridge {
+    url: String,
+    token: Option<String>,
+    http: Client,
+    session: Option<String>,
+}
+
+impl Bridge {
+    pub fn new(url: String, token: Option<String>) -> Self {
+        Bridge {
+            url,
+            token: token.filter(|t| !t.trim().is_empty()),
+            http: Client::new(),
+            session: None,
+        }
+    }
+
+    /// Ensures a daemon is answering, starting one if it is not.
+    ///
+    /// Starting it here is what makes the bundle work with nothing installed:
+    /// a client that has only ever been handed a binary gets a working vault
+    /// without the user having to know a daemon exists. If one is already up —
+    /// launchd, systemd, or another session that got here first — this finds it
+    /// and adds nothing.
+    pub async fn ensure_daemon(&self) -> io::Result<()> {
+        if self.ping().await {
+            tracing::debug!(url = %self.url, "daemon already answering");
+            return Ok(());
+        }
+        let exe = std::env::current_exe()?;
+        tracing::info!(url = %self.url, ?exe, "no daemon answering — starting one");
+        // Detached: this bridge exits with its client, and taking the vault's
+        // owner down with one session would strand every other session.
+        Command::new(exe)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let deadline = tokio::time::Instant::now() + START_TIMEOUT;
+        while tokio::time::Instant::now() < deadline {
+            sleep(Duration::from_millis(250)).await;
+            if self.ping().await {
+                return Ok(());
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("started a daemon but {} never answered", self.url),
+        ))
+    }
+
+    /// Whether something is listening and speaking HTTP at the mount path. A
+    /// bare GET is enough — any status at all proves a daemon is there, and
+    /// the transport answers a GET differently from a POST by design.
+    async fn ping(&self) -> bool {
+        self.http
+            .get(&self.url)
+            .timeout(Duration::from_millis(800))
+            .send()
+            .await
+            .is_ok()
+    }
+
+    /// Reads newline-delimited JSON-RPC from stdin, forwards each message to
+    /// the daemon, and writes whatever comes back to stdout.
+    pub async fn run(mut self) -> io::Result<()> {
+        let mut lines = BufReader::new(tokio::io::stdin()).lines();
+        let mut out = tokio::io::stdout();
+
+        while let Some(line) = lines.next_line().await? {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match self.forward(&line).await {
+                Ok(frames) => {
+                    for frame in frames {
+                        out.write_all(frame.as_bytes()).await?;
+                        out.write_all(b"\n").await?;
+                    }
+                    out.flush().await?;
+                }
+                // A transport failure is not a protocol answer, so there is
+                // nothing meaningful to write back to a client that is waiting
+                // on one. Log it and keep the pipe open — the next request may
+                // well succeed, and closing would kill the session outright.
+                Err(e) => tracing::warn!(error = %e, "forwarding to the daemon failed"),
+            }
+        }
+        Ok(())
+    }
+
+    async fn forward(&mut self, body: &str) -> Result<Vec<String>, reqwest::Error> {
+        let mut req = self
+            .http
+            .post(&self.url)
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            // The transport refuses a request that does not accept both.
+            .header(
+                ACCEPT,
+                HeaderValue::from_static("application/json, text/event-stream"),
+            )
+            .body(body.to_string());
+        if let Some(s) = &self.session {
+            req = req.header(SESSION_HEADER, s);
+        }
+        if let Some(t) = &self.token {
+            req = req.bearer_auth(t);
+        }
+
+        let resp = req.send().await?;
+        // The session id arrives on the initialize response and must be echoed
+        // on everything after it.
+        if self.session.is_none()
+            && let Some(v) = resp.headers().get(SESSION_HEADER)
+            && let Ok(v) = v.to_str()
+        {
+            self.session = Some(v.to_string());
+        }
+        let content_type = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let text = resp.text().await?;
+
+        Ok(if content_type.starts_with("text/event-stream") {
+            parse_sse(&text)
+        } else if text.trim().is_empty() {
+            // 202 to a notification: nothing to relay, and writing an empty
+            // line would look like a malformed frame to the client.
+            Vec::new()
+        } else {
+            vec![text]
+        })
+    }
+}
+
+/// Pulls the JSON payloads out of an SSE body.
+///
+/// Only `data:` carries protocol; `event:`, `id:` and comments are transport
+/// bookkeeping the stdio client neither sees nor needs.
+fn parse_sse(body: &str) -> Vec<String> {
+    body.lines()
+        .filter_map(|l| l.strip_prefix("data:"))
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_sse;
+
+    #[test]
+    fn only_data_lines_survive_an_sse_frame() {
+        let body = ": keep-alive\nevent: message\nid: 3\ndata: {\"jsonrpc\":\"2.0\",\"id\":1}\n\n";
+        assert_eq!(parse_sse(body), vec![r#"{"jsonrpc":"2.0","id":1}"#]);
+    }
+
+    #[test]
+    fn a_stream_carrying_several_messages_relays_all_of_them() {
+        let body = "data: {\"id\":1}\n\ndata: {\"id\":2}\n\n";
+        assert_eq!(parse_sse(body), vec![r#"{"id":1}"#, r#"{"id":2}"#]);
+    }
+
+    #[test]
+    fn a_keep_alive_only_frame_relays_nothing() {
+        assert!(parse_sse(": ping\n\n").is_empty());
+    }
+}


### PR DESCRIPTION
kaeru is deliberately not a stdio server, and that decision is right: the substrate is a single-writer RocksDB, so a subprocess per agent session would race for the LOCK and the second one would lose. The README says so in as many words.

What was never written down is the cost. **Most MCP clients only know how to spawn a server over stdio** — Claude Desktop among them — so they could not reach kaeru at all. Only clients that speak the HTTP transport could connect.

## `kaeru-mcp --stdio`

The client spawns a relay; the relay forwards its session to the one daemon, starting it first if nothing answers. Each client gets the stdio server it expects, and the vault still has exactly one writer.

**It relays frames rather than modelling them.** A proxy built from an MCP client and an MCP server would have to understand every method in order to pass it on, and would silently drop whatever it had not been taught — a new method, a notification, a capability added upstream. This forwards the JSON-RPC that arrives and returns what comes back, carrying the session header across, so it stays correct as the protocol grows.

Logs go to stderr. stdout carries the protocol, and one stray byte there is a malformed frame.

### Verified

Against the live daemon:

```
initialize   → serverInfo returned
tools/list   → 69 verbs
tools/call   → initiatives returned its content
```

On an empty port with a scratch vault: nothing answering → relay logs `no daemon answering`, starts one, `tools/list` returns 69 verbs, and the daemon is still up after the relay exits. It is spawned detached on purpose — taking the vault's owner down with one session would strand every other session.

## The bundle

`package-release.sh` now writes a `.mcpb` beside each tarball. An MCP Bundle is a zip carrying the binary and a manifest, so a client that installs one needs **no toolchain and no separate download**.

The manifest runs the binary with `--stdio`, never bare. Bare is the second daemon this whole change exists to avoid, and it fails on the RocksDB lock exactly as the README predicts.

The same script generates `dist/server.json` for the [MCP Registry](https://registry.modelcontextprotocol.io) with a download URL and a SHA-256 per bundle. Generated rather than hand-kept for the reason a sitemap is: both change every release, and a hand-edited one publishes last release's hash.

Both files validate against their published schemas — MCPB manifest v0.3, server.json 2025-12-11.

Publishing stays a maintainer action, once per release:

```bash
mcp-publisher login github && mcp-publisher publish dist/server.json
```

## Why bother

kaeru is in no MCP directory today — not the official registry (0 results), not Glama (404). Three competing memory servers are, which is why a category search for *"MCP server for agent memory across sessions"* returns them and not kaeru. This is the gap that closes at the next release.

## Notes for review

- The `--stdio` flag is read straight off `argv`; the daemon has no other arguments and a parser for exactly one would be furniture.
- `tokio` gains `io-std`, `io-util` and `process` — stdin/stdout and spawning the daemon.
- 303 tests green, `cargo fmt --check` clean, `clippy` clean over the new module.
- A `.mcpb` was packed and opened locally to confirm the layout (`manifest.json` + `server/kaeru-mcp`) and that the version and platform substitutions land.
